### PR TITLE
feat: membership 관리자 등록, 수정, 삭제, 목록 개발 및 에러코드 추가 (#31)

### DIFF
--- a/src/main/java/com/kt/common/ErrorCode.java
+++ b/src/main/java/com/kt/common/ErrorCode.java
@@ -26,6 +26,9 @@ public enum ErrorCode {
 	REQUIRED_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본 배송지는 최소 1개 이상 필요합니다."),
 	CANNOT_DELETE_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본 배송지는 삭제할 수 없습니다. 다른 배송지를 기본으로 설정 후 삭제해주세요."),
 
+	ALREADY_EXIST_MEMBERSHIP_LEVEL(HttpStatus.BAD_REQUEST, "이미 존재하는 멤버십 등급입니다."),
+	NOT_FOUND_MEMBERSHIP(HttpStatus.BAD_REQUEST, "멤버십을 찾을 수 없습니다.")
+
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/kt/controller/membership/AdminMembershipController.java
+++ b/src/main/java/com/kt/controller/membership/AdminMembershipController.java
@@ -1,0 +1,79 @@
+package com.kt.controller.membership;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.common.ApiResult;
+import com.kt.common.Paging;
+import com.kt.dto.membership.MembershipCreateRequest;
+import com.kt.dto.membership.MembershipListResponse;
+import com.kt.dto.membership.MembershipUpdateRequest;
+import com.kt.service.membership.MembershipService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Admin Membership", description = "관리자 멤버쉽 기능 관리  API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/memberships")
+public class AdminMembershipController {
+
+	private final MembershipService membershipService;
+
+	@PostMapping
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> create(
+		@Valid @RequestBody MembershipCreateRequest request
+	) {
+
+		membershipService.create(request);
+
+		return ApiResult.ok();
+	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Page<MembershipListResponse>> membershipAllList(
+		Paging paging
+	) {
+
+		Page<MembershipListResponse> memberships = membershipService.membershipAllList(paging.toPageable());
+
+		return ApiResult.ok(memberships);
+	}
+
+	@PutMapping("/{membershipId}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> update(
+		@PathVariable Long membershipId,
+		@Valid @RequestBody MembershipUpdateRequest request
+	) {
+
+		membershipService.update(membershipId, request);
+
+		return ApiResult.ok();
+	}
+
+	@DeleteMapping("/{membershipId}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> delete(
+		@PathVariable Long membershipId
+	) {
+
+		membershipService.delete(membershipId);
+
+		return ApiResult.ok();
+	}
+
+}

--- a/src/main/java/com/kt/domain/membership/Membership.java
+++ b/src/main/java/com/kt/domain/membership/Membership.java
@@ -11,13 +11,17 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 public class Membership {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    private String level; // BASIC, SILVER, GOLD 등등
+	private String level; // BASIC, SILVER, GOLD 등등
 
-    public Membership(String level) {
-        this.level = level;
-    }
+	public Membership(String level) {
+			this.level = level;
+	}
+
+	public void update(String level) {
+		this.level = level;
+	}
 }

--- a/src/main/java/com/kt/dto/membership/MembershipCreateRequest.java
+++ b/src/main/java/com/kt/dto/membership/MembershipCreateRequest.java
@@ -1,0 +1,9 @@
+package com.kt.dto.membership;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MembershipCreateRequest(
+	@NotBlank(message = "등급 이름은 필수입니다")
+	String level
+) {
+}

--- a/src/main/java/com/kt/dto/membership/MembershipListResponse.java
+++ b/src/main/java/com/kt/dto/membership/MembershipListResponse.java
@@ -1,0 +1,22 @@
+package com.kt.dto.membership;
+
+import org.springframework.data.domain.Page;
+
+import com.kt.domain.membership.Membership;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record MembershipListResponse(
+		Long id,
+		String level
+) {
+	public static Page<MembershipListResponse> fromList(Page<Membership> page) {
+		return page.map(membership -> new MembershipListResponse(
+			membership.getId(),
+			membership.getLevel()
+		));
+	}
+
+	@QueryProjection
+	public MembershipListResponse {
+	}
+}

--- a/src/main/java/com/kt/dto/membership/MembershipUpdateRequest.java
+++ b/src/main/java/com/kt/dto/membership/MembershipUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.kt.dto.membership;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MembershipUpdateRequest(
+	@NotBlank(message = "등급 이름은 필수입니다")
+	String level
+) {
+}

--- a/src/main/java/com/kt/repository/membership/MembershipRepository.java
+++ b/src/main/java/com/kt/repository/membership/MembershipRepository.java
@@ -2,10 +2,17 @@ package com.kt.repository.membership;
 
 import java.util.Optional;
 
+import com.kt.common.CustomException;
+import com.kt.common.ErrorCode;
 import com.kt.domain.membership.Membership;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
-    Optional<Membership> findByLevel(String level);
+	default Membership findByIdOrThrow(Long id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
+
+	Optional<Membership> findByLevel(String level);
 }

--- a/src/main/java/com/kt/repository/membership/MembershipRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/membership/MembershipRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.kt.repository.membership;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.dto.membership.MembershipListResponse;
+
+public interface MembershipRepositoryCustom {
+	Page<MembershipListResponse> membershipAllList(Pageable pageable);
+}

--- a/src/main/java/com/kt/repository/membership/MembershipRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/membership/MembershipRepositoryCustomImpl.java
@@ -1,0 +1,42 @@
+package com.kt.repository.membership;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.kt.domain.membership.QMembership;
+import com.kt.dto.membership.MembershipListResponse;
+import com.kt.dto.membership.QMembershipListResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MembershipRepositoryCustomImpl implements  MembershipRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+	private final QMembership membership = QMembership.membership;
+
+	@Override
+	public Page<MembershipListResponse> membershipAllList(Pageable pageable) {
+
+		var content = queryFactory
+			.select(new QMembershipListResponse(
+				membership.id,
+				membership.level
+			))
+			.from(membership)
+			.orderBy(membership.id.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		var total = queryFactory
+			.select(membership.id)
+			.from(membership)
+			.fetch().size();
+
+		return new PageImpl<>(content, pageable, total);
+	}
+}

--- a/src/main/java/com/kt/service/membership/MembershipService.java
+++ b/src/main/java/com/kt/service/membership/MembershipService.java
@@ -1,0 +1,56 @@
+package com.kt.service.membership;
+
+import java.util.ArrayList;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.common.ErrorCode;
+import com.kt.common.Preconditions;
+import com.kt.domain.membership.Membership;
+import com.kt.dto.membership.MembershipCreateRequest;
+import com.kt.dto.membership.MembershipListResponse;
+import com.kt.dto.membership.MembershipUpdateRequest;
+import com.kt.repository.membership.MembershipRepository;
+import com.kt.repository.membership.MembershipRepositoryCustom;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MembershipService {
+
+	private final MembershipRepository membershipRepository;
+	private final MembershipRepositoryCustom membershipRepositoryCustom;
+
+	public void create(MembershipCreateRequest request) {
+		Membership membership = new Membership(
+			request.level()
+		);
+
+		membershipRepository.save(membership);
+	}
+
+	public Page<MembershipListResponse> membershipAllList(Pageable pageable) {
+
+		return membershipRepositoryCustom.membershipAllList(pageable);
+	}
+
+	public void update(Long membershipId, MembershipUpdateRequest request) {
+		var membership = membershipRepository.findByIdOrThrow(membershipId, ErrorCode.NOT_FOUND_MEMBERSHIP);
+
+		Preconditions.validate(membershipRepository.findByLevel(request.level()).isEmpty(), ErrorCode.ALREADY_EXIST_MEMBERSHIP_LEVEL);
+
+		membership.update(request.level());
+	}
+
+	public void delete(Long membershipId) {
+		var membership = membershipRepository.findByIdOrThrow(membershipId, ErrorCode.NOT_FOUND_MEMBERSHIP);
+
+		membershipRepository.delete(membership);
+	}
+
+}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #31


## 🔨변경 사항(Changes)
1. 멤버쉽 등록
2. 멤버쉽 수정
3. 멤버쉽 삭제
4. 멤버쉽 목록(페이징 및 querydsl 사용)

## 😉리뷰 요구사항
관리자 기본 CRUD 입니다, 관리자는 추후 권한 부분만 추가하면 될 것 같습니다
