### PR TITLE
feat: discount 정책 추가, 수정, 삭제, 전체 목록, 상세 조회 추가 (#19)

### DIFF
--- a/src/main/java/com/kt/common/ErrorCode.java
+++ b/src/main/java/com/kt/common/ErrorCode.java
@@ -33,7 +33,10 @@ public enum ErrorCode {
 	CANNOT_DELETE_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본 배송지는 삭제할 수 없습니다. 다른 배송지를 기본으로 설정 후 삭제해주세요."),
 
 	ALREADY_EXIST_MEMBERSHIP_LEVEL(HttpStatus.BAD_REQUEST, "이미 존재하는 멤버십 등급입니다."),
-	NOT_FOUND_MEMBERSHIP(HttpStatus.BAD_REQUEST, "멤버십을 찾을 수 없습니다.")
+	NOT_FOUND_MEMBERSHIP(HttpStatus.BAD_REQUEST, "멤버십을 찾을 수 없습니다."),
+	DISCOUNT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 멤버십은 이미 할인 정책이 존재합니다"),
+
+	NOT_FOUND_DISCOUNT(HttpStatus.BAD_REQUEST, "할인 정책을 찾을 수 없습니다.")
 
 	;
 

--- a/src/main/java/com/kt/controller/discount/AdminDiscountController.java
+++ b/src/main/java/com/kt/controller/discount/AdminDiscountController.java
@@ -1,19 +1,93 @@
 package com.kt.controller.discount;
 
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kt.common.ApiResult;
+import com.kt.common.Paging;
+import com.kt.dto.discount.DiscountCreateRequest;
+import com.kt.dto.discount.DiscountDetailResponse;
+import com.kt.dto.discount.DiscountListResponse;
+import com.kt.dto.discount.DiscountUpdateRequest;
 import com.kt.service.discount.DiscountService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Admin Discount", description = "관리자 할인 기능 관리 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/admin/discounts")
+@RequestMapping("/api/admin")
 public class AdminDiscountController {
 
 	private final DiscountService discountService;
+
+	// 역할을 어디에 두어야 하는가 -> 멤버십 페이지 -> 멤버십 선택 -> 할인 정책 생성 -> 멤버십에서 제어해야한다? 아니면 할인에서 제어한다?
+	@PostMapping("/memberships/{membershipId}/discount")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> create(
+		@PathVariable Long membershipId,
+		@Valid @RequestBody DiscountCreateRequest request
+	) {
+
+		discountService.create(membershipId, request);
+
+		return ApiResult.ok();
+	}
+
+	@GetMapping("discounts")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Page<DiscountListResponse>> discountAllList(
+		Paging paging
+	) {
+
+		Page<DiscountListResponse> discounts = discountService.discountAllList(paging.toPageable());
+
+		return ApiResult.ok(discounts);
+	}
+
+	@PutMapping("/discounts/{discountId}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> update(
+		@PathVariable Long discountId,
+		@Valid @RequestBody DiscountUpdateRequest request
+	) {
+
+		discountService.update(discountId, request);
+
+		return ApiResult.ok();
+	}
+
+	@DeleteMapping("/discounts/{discountId}")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<Void> delete(
+		@PathVariable Long discountId
+	) {
+
+		discountService.delete(discountId);
+
+		return ApiResult.ok();
+	}
+
+	@GetMapping("/discounts/{discountId}/detail")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResult<DiscountDetailResponse> detail(
+		@PathVariable Long discountId
+	) {
+
+		DiscountDetailResponse detail = discountService.detail(discountId);
+
+		return ApiResult.ok(detail);
+	}
 
 }

--- a/src/main/java/com/kt/domain/discount/Discount.java
+++ b/src/main/java/com/kt/domain/discount/Discount.java
@@ -1,12 +1,17 @@
 package com.kt.domain.discount;
 
+import com.kt.domain.membership.Membership;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,4 +34,20 @@ public class Discount {
 	@Column(nullable = false)
 	private Integer value;
 
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "membership_id")
+	private Membership membership;
+
+	public Discount(String name, DiscountType type, Integer value, Membership membership) {
+		this.name = name;
+		this.type = type;
+		this.value = value;
+		this.membership = membership;
+	}
+
+	public void update(String name, DiscountType type, Integer value) {
+		this.name = name;
+		this.type = type;
+		this.value = value;
+	}
 }

--- a/src/main/java/com/kt/domain/membership/Membership.java
+++ b/src/main/java/com/kt/domain/membership/Membership.java
@@ -1,5 +1,6 @@
 package com.kt.domain.membership;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,6 +16,7 @@ public class Membership {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(nullable = false, length = 30)
 	private String level; // BASIC, SILVER, GOLD 등등
 
 	public Membership(String level) {

--- a/src/main/java/com/kt/dto/discount/DiscountCreateRequest.java
+++ b/src/main/java/com/kt/dto/discount/DiscountCreateRequest.java
@@ -1,0 +1,21 @@
+package com.kt.dto.discount;
+
+import com.kt.domain.discount.DiscountType;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DiscountCreateRequest(
+
+	@NotBlank(message = "멤버십 이름은 필수입니다")
+	String name,
+
+	@NotNull(message = "할인 타입은 필수입니다")
+	DiscountType type,
+
+	@NotNull(message = "할인 값은 필수입니다")
+	@Min(value = 0, message = "할인 값은 0 이상이어야 합니다")
+	Integer value
+) {
+}

--- a/src/main/java/com/kt/dto/discount/DiscountDetailResponse.java
+++ b/src/main/java/com/kt/dto/discount/DiscountDetailResponse.java
@@ -1,0 +1,13 @@
+package com.kt.dto.discount;
+
+import com.kt.domain.discount.DiscountType;
+
+public record DiscountDetailResponse(
+	Long id,
+	String name,
+	DiscountType type,
+	Integer value,
+	Long membershipId,
+	String membershipLevel
+) {
+}

--- a/src/main/java/com/kt/dto/discount/DiscountListResponse.java
+++ b/src/main/java/com/kt/dto/discount/DiscountListResponse.java
@@ -1,0 +1,18 @@
+package com.kt.dto.discount;
+
+import com.kt.domain.discount.DiscountType;
+import com.querydsl.core.annotations.QueryProjection;
+
+public record DiscountListResponse(
+		Long id,
+		String name,
+		DiscountType type,
+		Integer value,
+		Long membershipId,
+		String membershipName
+) {
+
+	@QueryProjection
+	public DiscountListResponse {
+	}
+}

--- a/src/main/java/com/kt/dto/discount/DiscountUpdateRequest.java
+++ b/src/main/java/com/kt/dto/discount/DiscountUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.kt.dto.discount;
+
+import com.kt.domain.discount.DiscountType;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record DiscountUpdateRequest(
+	@NotBlank(message = "멤버십 이름은 필수입니다")
+	String name,
+
+	@NotNull(message = "할인 타입은 필수입니다")
+	DiscountType type,
+
+	@NotNull(message = "할인 값은 필수입니다")
+	@Min(value = 0, message = "할인 값은 0 이상이어야 합니다")
+	Integer value
+) {
+}

--- a/src/main/java/com/kt/repository/discount/DiscountRepository.java
+++ b/src/main/java/com/kt/repository/discount/DiscountRepository.java
@@ -1,8 +1,26 @@
 package com.kt.repository.discount;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.kt.common.CustomException;
+import com.kt.common.ErrorCode;
 import com.kt.domain.discount.Discount;
 
 public interface DiscountRepository extends JpaRepository<Discount, Long> {
+
+	default Discount findByIdOrThrow(Long id, ErrorCode errorCode) {
+		return findById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
+
+	default Discount findDiscountDetailByIdOrThrow(Long id, ErrorCode errorCode) {
+		return findWithMembershipById(id).orElseThrow(() -> new CustomException(errorCode));
+	}
+
+	@EntityGraph(attributePaths = {"membership"})
+	Optional<Discount> findWithMembershipById(Long id);
+
+	boolean existsByMembershipId(Long membershipId);
 }

--- a/src/main/java/com/kt/repository/discount/DiscountRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/discount/DiscountRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.kt.repository.discount;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kt.dto.discount.DiscountListResponse;
+
+public interface DiscountRepositoryCustom {
+	Page<DiscountListResponse> discountAllList(Pageable pageable);
+}

--- a/src/main/java/com/kt/repository/discount/DiscountRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/discount/DiscountRepositoryCustomImpl.java
@@ -1,0 +1,50 @@
+package com.kt.repository.discount;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.kt.domain.discount.QDiscount;
+import com.kt.domain.membership.QMembership;
+import com.kt.dto.discount.DiscountListResponse;
+import com.kt.dto.discount.QDiscountListResponse;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscountRepositoryCustomImpl implements DiscountRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private final QDiscount discount = QDiscount.discount;
+	private final QMembership membership = QMembership.membership;
+
+	@Override
+	public Page<DiscountListResponse> discountAllList(Pageable pageable) {
+
+		var content = queryFactory
+			.select(new QDiscountListResponse(
+				discount.id,
+				discount.name,
+				discount.type,
+				discount.value,
+				membership.id,
+				membership.level
+			))
+			.from(discount)
+			.join(membership).on(discount.membership.id.eq(membership.id))
+			.orderBy(membership.id.asc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		var total = queryFactory
+			.select(discount.id)
+			.from(discount)
+			.fetch().size();
+
+		return new PageImpl<>(content, pageable, total);
+	}
+}

--- a/src/main/java/com/kt/service/discount/DiscountService.java
+++ b/src/main/java/com/kt/service/discount/DiscountService.java
@@ -1,9 +1,20 @@
 package com.kt.service.discount;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.common.ErrorCode;
+import com.kt.common.Preconditions;
+import com.kt.domain.discount.Discount;
+import com.kt.dto.discount.DiscountCreateRequest;
+import com.kt.dto.discount.DiscountDetailResponse;
+import com.kt.dto.discount.DiscountListResponse;
+import com.kt.dto.discount.DiscountUpdateRequest;
 import com.kt.repository.discount.DiscountRepository;
+import com.kt.repository.discount.DiscountRepositoryCustom;
+import com.kt.repository.membership.MembershipRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,5 +24,62 @@ import lombok.RequiredArgsConstructor;
 public class DiscountService {
 
 	private final DiscountRepository discountRepository;
+	private final MembershipRepository membershipRepository;
+	private final DiscountRepositoryCustom discountRepositoryCustom;
 
+	public void create(Long membershipId, DiscountCreateRequest request) {
+
+		var membership = membershipRepository.findByIdOrThrow(membershipId, ErrorCode.NOT_FOUND_MEMBERSHIP);
+
+		Preconditions.validate(!discountRepository.existsByMembershipId(membershipId), ErrorCode.DISCOUNT_ALREADY_EXISTS);
+
+		var discount = new Discount(
+			request.name(),
+			request.type(),
+			request.value(),
+			membership
+		);
+
+		discountRepository.save(discount);
+	}
+
+	public Page<DiscountListResponse> discountAllList(Pageable pageable) {
+		return discountRepositoryCustom.discountAllList(pageable);
+	}
+
+	public void update(Long discountId, DiscountUpdateRequest request) {
+
+		var discount = discountRepository.findByIdOrThrow(discountId, ErrorCode.NOT_FOUND_DISCOUNT);
+
+		discount.update(
+			request.name(),
+			request.type(),
+			request.value()
+		);
+	}
+
+	public void delete(Long discountId) {
+
+		var discount = discountRepository.findByIdOrThrow(discountId, ErrorCode.NOT_FOUND_DISCOUNT);
+
+		discountRepository.delete(discount);
+	}
+
+	public DiscountDetailResponse detail(Long discountId) {
+
+		// 1+N 문제, 현재는 단건 조회라서 문제는 없겠지만 membership 추가 쿼리 발생
+		// var discount = discountRepository.findByIdOrThrow(discountId, ErrorCode.NOT_FOUND_DISCOUNT);
+
+		// 해결 방법: EntityGraph 사용
+		var discount = discountRepository.findDiscountDetailByIdOrThrow(discountId, ErrorCode.NOT_FOUND_DISCOUNT);
+
+		return new DiscountDetailResponse(
+			discount.getId(),
+			discount.getName(),
+			discount.getType(),
+			discount.getValue(),
+			discount.getMembership().getId(),
+			discount.getMembership().getLevel()
+		);
+	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #19

## 🔨변경 사항(Changes)
1. discount 정책 추가
2. discount 정책 수정
3. discount 정책 삭제
4. discount 정책 전체 목록 조회(querydsl)
5. discount 상세 조회(EntityGraph)
6. errorcode 추가

## 😉리뷰 요구사항
discount와 membership이 1:1관계라서 1+N 문제는 없을거라고 생각했습니다
근데 discount 상세 조회 시 membership 정보(이름 등)를 같이 가져오면 getMembership().getId() 코드에서 불필요하게 membership 조회 추가 쿼리가 나가고 있어서 21일 수업에서 배운 EntityGraph를 활용해봤습니다 맞게 사용된 것인지 service쪽 확인 부탁드리겠습니다
