### PR TITLE
feat: product 관리자용 수정 api 개발

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       MYSQL_ROOT_PASSWORD: 1234
       MYSQL_DATABASE: shopping
     ports:
-      - "3308:3306"
+      - "3306:3306"
     platform: linux/arm64
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       MYSQL_ROOT_PASSWORD: 1234
       MYSQL_DATABASE: shopping
     ports:
-      - "3306:3306"
+      - "3308:3306"
     platform: linux/arm64
 

--- a/src/main/java/com/kt/common/exception/ApiAdvice.java
+++ b/src/main/java/com/kt/common/exception/ApiAdvice.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.exception;
 
 import java.util.Arrays;
 
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.kt.common.response.ErrorResponse;
 
 import io.swagger.v3.oas.annotations.Hidden;
 

--- a/src/main/java/com/kt/common/exception/CustomException.java
+++ b/src/main/java/com/kt/common/exception/CustomException.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.exception;
 
 import lombok.Getter;
 

--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/kt/common/request/Paging.java
+++ b/src/main/java/com/kt/common/request/Paging.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.request;
 
 import org.springframework.data.domain.PageRequest;
 

--- a/src/main/java/com/kt/common/response/ApiResult.java
+++ b/src/main/java/com/kt/common/response/ApiResult.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/kt/common/response/ErrorResponse.java
+++ b/src/main/java/com/kt/common/response/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.response;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/kt/common/support/BaseEntity.java
+++ b/src/main/java/com/kt/common/support/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.support;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/kt/common/support/ObjectUtils.java
+++ b/src/main/java/com/kt/common/support/ObjectUtils.java
@@ -1,0 +1,7 @@
+package com.kt.common.support;
+
+public class ObjectUtils {
+	public static <T> T orElse(T newValue, T originalValue) {
+		return newValue != null ? newValue : originalValue;
+	}
+}

--- a/src/main/java/com/kt/common/support/Preconditions.java
+++ b/src/main/java/com/kt/common/support/Preconditions.java
@@ -1,4 +1,7 @@
-package com.kt.common;
+package com.kt.common.support;
+
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 
 public class Preconditions {
 	public static void validate(boolean expression, ErrorCode errorCode) {

--- a/src/main/java/com/kt/common/support/SwaggerAssistance.java
+++ b/src/main/java/com/kt/common/support/SwaggerAssistance.java
@@ -1,4 +1,4 @@
-package com.kt.common;
+package com.kt.common.support;
 
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;

--- a/src/main/java/com/kt/controller/cart/CartController.java
+++ b/src/main/java/com/kt/controller/cart/CartController.java
@@ -1,7 +1,7 @@
 package com.kt.controller.cart;
 
-import com.kt.common.ApiResult;
-import com.kt.common.SwaggerAssistance;
+import com.kt.common.response.ApiResult;
+import com.kt.common.support.SwaggerAssistance;
 import com.kt.dto.cart.CartCreateRequest;
 import com.kt.dto.cart.CartUpdateQuantityRequest;
 import com.kt.service.cart.CartService;

--- a/src/main/java/com/kt/controller/category/CategoryController.java
+++ b/src/main/java/com/kt/controller/category/CategoryController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.common.ApiResult;
+import com.kt.common.response.ApiResult;
 import com.kt.dto.category.CategoryCreateRequest;
 import com.kt.service.category.CategoryService;
 

--- a/src/main/java/com/kt/controller/discount/AdminDiscountController.java
+++ b/src/main/java/com/kt/controller/discount/AdminDiscountController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.common.ApiResult;
-import com.kt.common.Paging;
+import com.kt.common.response.ApiResult;
+import com.kt.common.request.Paging;
 import com.kt.dto.discount.DiscountCreateRequest;
 import com.kt.dto.discount.DiscountDetailResponse;
 import com.kt.dto.discount.DiscountListResponse;

--- a/src/main/java/com/kt/controller/membership/AdminMembershipController.java
+++ b/src/main/java/com/kt/controller/membership/AdminMembershipController.java
@@ -12,8 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.common.ApiResult;
-import com.kt.common.Paging;
+import com.kt.common.response.ApiResult;
+import com.kt.common.request.Paging;
 import com.kt.dto.membership.MembershipCreateRequest;
 import com.kt.dto.membership.MembershipListResponse;
 import com.kt.dto.membership.MembershipUpdateRequest;

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -39,8 +39,8 @@ public class AdminProductController {
 	}
 
 	@GetMapping("/{productId}")
-	public ApiResult<ProductResponse> getProductById(@PathVariable("productId") Long productId) {
-		var product = productService.getProduct(productId);
+	public ApiResult<ProductResponse> getProductDetail(@PathVariable("productId") Long productId) {
+		var product = productService.getProductDetail(productId);
 		return ApiResult.ok(product);
 	}
 }

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -14,6 +14,7 @@ import com.kt.common.response.ApiResult;
 import com.kt.dto.product.ProductCreateRequest;
 import com.kt.dto.product.ProductListResponse;
 import com.kt.dto.product.ProductResponse;
+import com.kt.dto.product.ProductUpdateCategoryRequest;
 import com.kt.dto.product.ProductUpdateRequest;
 import com.kt.service.product.ProductService;
 
@@ -47,8 +48,15 @@ public class AdminProductController {
 	}
 
 	@PutMapping("/{productId}")
-	public ApiResult<Void>  update(@PathVariable("productId") Long productId, @Valid @RequestBody ProductUpdateRequest request) {
+	public ApiResult<Void> update(@PathVariable("productId") Long productId, @Valid @RequestBody ProductUpdateRequest request) {
 		productService.updateProduct(productId, request);
+		return ApiResult.ok();
+	}
+
+	@PutMapping("/{productId}/category")
+	public ApiResult<Void> updateCategory(@PathVariable("productId") Long productId, @RequestBody
+		ProductUpdateCategoryRequest request) {
+		productService.updateProductCategory(productId, request);
 		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -5,14 +5,16 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.common.ApiResult;
+import com.kt.common.response.ApiResult;
 import com.kt.dto.product.ProductCreateRequest;
 import com.kt.dto.product.ProductListResponse;
 import com.kt.dto.product.ProductResponse;
+import com.kt.dto.product.ProductUpdateRequest;
 import com.kt.service.product.ProductService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,5 +44,11 @@ public class AdminProductController {
 	public ApiResult<ProductResponse> getProductDetail(@PathVariable("productId") Long productId) {
 		var product = productService.getProductDetail(productId);
 		return ApiResult.ok(product);
+	}
+
+	@PutMapping("/{productId}")
+	public ApiResult<Void>  update(@PathVariable("productId") Long productId, @Valid @RequestBody ProductUpdateRequest request) {
+		productService.updateProduct(productId, request);
+		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.response.ApiResult;
-import com.kt.dto.product.ProductCreateRequest;
-import com.kt.dto.product.ProductListResponse;
-import com.kt.dto.product.ProductResponse;
-import com.kt.dto.product.ProductUpdateCategoryRequest;
-import com.kt.dto.product.ProductUpdateRequest;
+import com.kt.dto.product.request.ProductCreateRequest;
+import com.kt.dto.product.response.ProductListResponse;
+import com.kt.dto.product.response.ProductResponse;
+import com.kt.dto.product.request.ProductUpdateCategoryRequest;
+import com.kt.dto.product.request.ProductUpdateRequest;
 import com.kt.service.product.ProductService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/kt/controller/review/AdminReviewController.java
+++ b/src/main/java/com/kt/controller/review/AdminReviewController.java
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.common.ApiResult;
-import com.kt.common.SwaggerAssistance;
+import com.kt.common.response.ApiResult;
+import com.kt.common.support.SwaggerAssistance;
 import com.kt.service.review.ReviewService;
 
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/src/main/java/com/kt/controller/review/ReviewController.java
+++ b/src/main/java/com/kt/controller/review/ReviewController.java
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.kt.common.ApiResult;
-import com.kt.common.Paging;
-import com.kt.common.SwaggerAssistance;
+import com.kt.common.response.ApiResult;
+import com.kt.common.request.Paging;
+import com.kt.common.support.SwaggerAssistance;
 import com.kt.dto.review.ReviewCreateRequest;
 import com.kt.dto.review.ReviewListResponse;
 import com.kt.dto.review.ReviewUpdateRequest;

--- a/src/main/java/com/kt/controller/user/UserController.java
+++ b/src/main/java/com/kt/controller/user/UserController.java
@@ -1,6 +1,6 @@
 package com.kt.controller.user;
 
-import com.kt.common.ApiResult;
+import com.kt.common.response.ApiResult;
 import com.kt.dto.user.UserCreateRequest;
 import com.kt.dto.user.UserLoginRequest;
 import com.kt.dto.user.UserLoginResponse;

--- a/src/main/java/com/kt/domain/cart/Cart.java
+++ b/src/main/java/com/kt/domain/cart/Cart.java
@@ -1,6 +1,6 @@
 package com.kt.domain.cart;
 
-import com.kt.common.BaseEntity;
+import com.kt.common.support.BaseEntity;
 import com.kt.domain.product.Product;
 import com.kt.domain.user.User;
 import jakarta.persistence.*;

--- a/src/main/java/com/kt/domain/category/Category.java
+++ b/src/main/java/com/kt/domain/category/Category.java
@@ -3,15 +3,9 @@ package com.kt.domain.category;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.logging.log4j.util.Strings;
-
-import com.kt.common.ErrorCode;
-import com.kt.common.Preconditions;
 import com.kt.domain.product.Product;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;

--- a/src/main/java/com/kt/domain/product/Product.java
+++ b/src/main/java/com/kt/domain/product/Product.java
@@ -51,11 +51,15 @@ public class Product extends BaseEntity {
 		this.category = category;
 	}
 
-	public void updateProduct(String name, String description, Long price, Long stock) {
+	public void update(String name, String description, Long price, Long stock) {
 		this.name = name;
 		this.description = description;
 		this.price = price;
 		this.stock = stock;
+	}
+
+	public void updateCategory(Category category) {
+		this.category = category;
 	}
 
 }

--- a/src/main/java/com/kt/domain/product/Product.java
+++ b/src/main/java/com/kt/domain/product/Product.java
@@ -3,11 +3,7 @@ package com.kt.domain.product;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.logging.log4j.util.Strings;
-
-import com.kt.common.BaseEntity;
-import com.kt.common.ErrorCode;
-import com.kt.common.Preconditions;
+import com.kt.common.support.BaseEntity;
 import com.kt.domain.category.Category;
 import com.kt.domain.variant.Variant;
 
@@ -53,6 +49,13 @@ public class Product extends BaseEntity {
 		this.isDeleted = false;
 
 		this.category = category;
+	}
+
+	public void updateProduct(String name, String description, Long price, Long stock) {
+		this.name = name;
+		this.description = description;
+		this.price = price;
+		this.stock = stock;
 	}
 
 }

--- a/src/main/java/com/kt/domain/review/Review.java
+++ b/src/main/java/com/kt/domain/review/Review.java
@@ -1,9 +1,9 @@
 package com.kt.domain.review;
 
 
-import com.kt.common.BaseEntity;
-import com.kt.common.ErrorCode;
-import com.kt.common.Preconditions;
+import com.kt.common.support.BaseEntity;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.Preconditions;
 import com.kt.domain.user.User;
 
 import jakarta.persistence.Column;

--- a/src/main/java/com/kt/domain/user/User.java
+++ b/src/main/java/com/kt/domain/user/User.java
@@ -1,10 +1,8 @@
 package com.kt.domain.user;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
 
-import com.kt.common.BaseEntity;
+import com.kt.common.support.BaseEntity;
 import com.kt.domain.membership.Membership; //멤버쉽 임의 생성
 
 import jakarta.persistence.*;

--- a/src/main/java/com/kt/dto/product/ProductUpdateCategoryRequest.java
+++ b/src/main/java/com/kt/dto/product/ProductUpdateCategoryRequest.java
@@ -1,0 +1,6 @@
+package com.kt.dto.product;
+
+public record ProductUpdateCategoryRequest(
+	Long categoryId
+) {
+}

--- a/src/main/java/com/kt/dto/product/ProductUpdateRequest.java
+++ b/src/main/java/com/kt/dto/product/ProductUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.kt.dto.product;
+
+import jakarta.validation.constraints.Min;
+
+public record ProductUpdateRequest(
+	String name,
+	String description,
+	@Min(value = 0, message = "가격은 0 이상이어야 합니다")
+	Long price,
+	@Min(value = 0, message = "수량은 0 이상이어야 합니다")
+	Long stock
+) {
+}

--- a/src/main/java/com/kt/dto/product/request/ProductCreateRequest.java
+++ b/src/main/java/com/kt/dto/product/request/ProductCreateRequest.java
@@ -1,4 +1,4 @@
-package com.kt.dto.product;
+package com.kt.dto.product.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/kt/dto/product/request/ProductUpdateCategoryRequest.java
+++ b/src/main/java/com/kt/dto/product/request/ProductUpdateCategoryRequest.java
@@ -1,4 +1,4 @@
-package com.kt.dto.product;
+package com.kt.dto.product.request;
 
 public record ProductUpdateCategoryRequest(
 	Long categoryId

--- a/src/main/java/com/kt/dto/product/request/ProductUpdateRequest.java
+++ b/src/main/java/com/kt/dto/product/request/ProductUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.kt.dto.product;
+package com.kt.dto.product.request;
 
 import jakarta.validation.constraints.Min;
 

--- a/src/main/java/com/kt/dto/product/response/ProductListResponse.java
+++ b/src/main/java/com/kt/dto/product/response/ProductListResponse.java
@@ -1,4 +1,4 @@
-package com.kt.dto.product;
+package com.kt.dto.product.response;
 
 import com.kt.domain.product.Product;
 

--- a/src/main/java/com/kt/dto/product/response/ProductResponse.java
+++ b/src/main/java/com/kt/dto/product/response/ProductResponse.java
@@ -1,4 +1,4 @@
-package com.kt.dto.product;
+package com.kt.dto.product.response;
 
 import com.kt.domain.product.Product;
 

--- a/src/main/java/com/kt/repository/category/CategoryRepository.java
+++ b/src/main/java/com/kt/repository/category/CategoryRepository.java
@@ -2,8 +2,8 @@ package com.kt.repository.category;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.category.Category;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {

--- a/src/main/java/com/kt/repository/discount/DiscountRepository.java
+++ b/src/main/java/com/kt/repository/discount/DiscountRepository.java
@@ -5,8 +5,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.discount.Discount;
 
 public interface DiscountRepository extends JpaRepository<Discount, Long> {

--- a/src/main/java/com/kt/repository/membership/MembershipRepository.java
+++ b/src/main/java/com/kt/repository/membership/MembershipRepository.java
@@ -2,8 +2,8 @@ package com.kt.repository.membership;
 
 import java.util.Optional;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.membership.Membership;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/kt/repository/product/ProductRepository.java
+++ b/src/main/java/com/kt/repository/product/ProductRepository.java
@@ -2,8 +2,8 @@ package com.kt.repository.product;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.product.Product;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {

--- a/src/main/java/com/kt/repository/review/ReviewRepository.java
+++ b/src/main/java/com/kt/repository/review/ReviewRepository.java
@@ -1,19 +1,10 @@
 package com.kt.repository.review;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.parameters.P;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.review.Review;
-import com.kt.domain.user.User;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 

--- a/src/main/java/com/kt/repository/user/UserRepository.java
+++ b/src/main/java/com/kt/repository/user/UserRepository.java
@@ -1,7 +1,7 @@
 package com.kt.repository.user;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.user.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/kt/security/JwtTokenProvider.java
+++ b/src/main/java/com/kt/security/JwtTokenProvider.java
@@ -1,7 +1,7 @@
 package com.kt.security;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.user.User;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/com/kt/service/discount/DiscountService.java
+++ b/src/main/java/com/kt/service/discount/DiscountService.java
@@ -5,8 +5,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.ErrorCode;
-import com.kt.common.Preconditions;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.Preconditions;
 import com.kt.domain.discount.Discount;
 import com.kt.dto.discount.DiscountCreateRequest;
 import com.kt.dto.discount.DiscountDetailResponse;

--- a/src/main/java/com/kt/service/membership/MembershipService.java
+++ b/src/main/java/com/kt/service/membership/MembershipService.java
@@ -1,14 +1,12 @@
 package com.kt.service.membership;
 
-import java.util.ArrayList;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.ErrorCode;
-import com.kt.common.Preconditions;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.Preconditions;
 import com.kt.domain.membership.Membership;
 import com.kt.dto.membership.MembershipCreateRequest;
 import com.kt.dto.membership.MembershipListResponse;

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -41,8 +41,8 @@ public class ProductService {
 			.map(ProductListResponse::from);
 	}
 
-	public ProductResponse getProduct(Long productId) {
-		var Product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
-		return ProductResponse.from(Product);
+	public ProductResponse getProductDetail(Long productId) {
+		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+		return ProductResponse.from(product);
 	}
 }

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -1,15 +1,19 @@
 package com.kt.service.product;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.ObjectUtils;
 import com.kt.domain.product.Product;
 import com.kt.dto.product.ProductCreateRequest;
 import com.kt.dto.product.ProductListResponse;
 import com.kt.dto.product.ProductResponse;
+import com.kt.dto.product.ProductUpdateRequest;
 import com.kt.repository.category.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
 
@@ -44,5 +48,16 @@ public class ProductService {
 	public ProductResponse getProductDetail(Long productId) {
 		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
 		return ProductResponse.from(product);
+	}
+
+	public void updateProduct(Long productId,  ProductUpdateRequest request) {
+		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+
+		product.updateProduct(
+			ObjectUtils.orElse(request.name(), product.getName()),
+			ObjectUtils.orElse(request.description(), product.getDescription()),
+			ObjectUtils.orElse(request.price(), product.getPrice()),
+			ObjectUtils.orElse(request.stock(), product.getStock())
+		);
 	}
 }

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -1,7 +1,5 @@
 package com.kt.service.product;
 
-import java.util.Optional;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -13,6 +11,7 @@ import com.kt.domain.product.Product;
 import com.kt.dto.product.ProductCreateRequest;
 import com.kt.dto.product.ProductListResponse;
 import com.kt.dto.product.ProductResponse;
+import com.kt.dto.product.ProductUpdateCategoryRequest;
 import com.kt.dto.product.ProductUpdateRequest;
 import com.kt.repository.category.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
@@ -40,24 +39,37 @@ public class ProductService {
 		productRepository.save(newProduct);
 	}
 
+
 	public Page<ProductListResponse> getProductList(Pageable pageable) {
 		return productRepository.findAll(pageable)
 			.map(ProductListResponse::from);
 	}
+
 
 	public ProductResponse getProductDetail(Long productId) {
 		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
 		return ProductResponse.from(product);
 	}
 
+
 	public void updateProduct(Long productId,  ProductUpdateRequest request) {
 		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
 
-		product.updateProduct(
+		product.update(
 			ObjectUtils.orElse(request.name(), product.getName()),
 			ObjectUtils.orElse(request.description(), product.getDescription()),
 			ObjectUtils.orElse(request.price(), product.getPrice()),
 			ObjectUtils.orElse(request.stock(), product.getStock())
+		);
+	}
+
+
+	public void updateProductCategory(Long productId, ProductUpdateCategoryRequest request) {
+		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+		var updateCategory = categoryRepository.findByIdOrThrow(request.categoryId(), ErrorCode.NOT_FOUND_CATEGORY);
+
+		product.updateCategory(
+			ObjectUtils.orElse(updateCategory, product.getCategory())
 		);
 	}
 }

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -8,11 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kt.common.exception.ErrorCode;
 import com.kt.common.support.ObjectUtils;
 import com.kt.domain.product.Product;
-import com.kt.dto.product.ProductCreateRequest;
-import com.kt.dto.product.ProductListResponse;
-import com.kt.dto.product.ProductResponse;
-import com.kt.dto.product.ProductUpdateCategoryRequest;
-import com.kt.dto.product.ProductUpdateRequest;
+import com.kt.dto.product.request.ProductCreateRequest;
+import com.kt.dto.product.response.ProductListResponse;
+import com.kt.dto.product.response.ProductResponse;
+import com.kt.dto.product.request.ProductUpdateCategoryRequest;
+import com.kt.dto.product.request.ProductUpdateRequest;
 import com.kt.repository.category.CategoryRepository;
 import com.kt.repository.product.ProductRepository;
 

--- a/src/main/java/com/kt/service/review/ReviewService.java
+++ b/src/main/java/com/kt/service/review/ReviewService.java
@@ -6,8 +6,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kt.common.ErrorCode;
-import com.kt.common.Preconditions;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.Preconditions;
 import com.kt.domain.review.Review;
 import com.kt.dto.review.ReviewCreateRequest;
 import com.kt.dto.review.ReviewListResponse;

--- a/src/main/java/com/kt/service/user/UserService.java
+++ b/src/main/java/com/kt/service/user/UserService.java
@@ -1,7 +1,7 @@
 package com.kt.service.user;
 
-import com.kt.common.CustomException;
-import com.kt.common.ErrorCode;
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.domain.auth.RefreshToken;
 import com.kt.domain.membership.Membership;
 import com.kt.domain.user.User;
@@ -18,9 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,6 @@ jwt:
   secret: ${kt.jwt.secret:kt-cloud-tech-up-shopping-202511171107}
   access-token-expiration: ${kt.jwt.access-token-expiration:300000}
   refresh-token-expiration: ${kt.jwt.refresh-token-expiration:43200000}
+
+server:
+  port: 8080


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #5 


## 🔨변경 사항(Changes)
- common 패키지 세분화
- product 관리자용 상품 정보 수정 api 개발
- product 관리자용 상품 카테고리 수정 api 개발


## 😉리뷰 요구사항
- common 패키지는 오늘(11/24) 강의에서 세분화한 기준과 동일하게 구조화했습니다
- product 정보 수정 요청 시, 일부 필드가 누락될 경우 null로 DB에 저장되는 문제를 방지하기 위해 ObjectUtils.orElse()를 사용했습니다.
혹시 이 검증 방식이 과하다고 판단되면, 조정할 계획이니 의견 부탁드립니다
- 불필요한 db 조회를 방지하기 위해, category 수정 기능은 추가 api로 분리하였습니다. 혹시 통일성에 어긋난다고 판단된다면, 다른 수정 필드 값들도 별도의 api로 분리할 계획이니 의견 부탁드립니다
