### PR TITLE
feat: product 관리자용 상태 변경 api 개발

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 
 	//product
 	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+	INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "상품 상태 변경이 이미 적용되었습니다"),
 
 	//category
 	NOT_FOUND_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),
@@ -46,14 +47,14 @@ public enum ErrorCode {
 	NOT_REVIEW_AUTHOR(HttpStatus.FORBIDDEN, "리뷰 작성자만 수정가능합니다."),
 	NOT_FOUND_REVIEW(HttpStatus.BAD_REQUEST, "리뷰를 찾을 수 없습니다."),
   
-  //membership
+    //membership
 	DISCOUNT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 멤버십은 이미 할인 정책이 존재합니다"),
 	NOT_FOUND_MEMBERSHIP(HttpStatus.BAD_REQUEST, "멤버십을 찾을 수 없습니다."),
 	ALREADY_EXIST_MEMBERSHIP_LEVEL(HttpStatus.BAD_REQUEST, "이미 존재하는 멤버십 등급입니다."),
 
 	//discount
 	NOT_FOUND_DISCOUNT(HttpStatus.BAD_REQUEST, "할인 정책을 찾을 수 없습니다."),
-	INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "이미 적용되었습니다"),
+
 
 	;
 

--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 	//product
 	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
 	INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "상품 상태 변경이 이미 적용되었습니다"),
+	INVALID_PRODUCT_STOCK(HttpStatus.BAD_REQUEST, "상품 수량이 부족합니다"),
 
 	//category
 	NOT_FOUND_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리를 찾을 수 없습니다."),

--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
 	NOT_FOUND_MEMBERSHIP(HttpStatus.BAD_REQUEST, "멤버십을 찾을 수 없습니다."),
 	DISCOUNT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 멤버십은 이미 할인 정책이 존재합니다"),
 	NOT_FOUND_DISCOUNT(HttpStatus.BAD_REQUEST, "할인 정책을 찾을 수 없습니다."),
+	INVALID_PRODUCT_STATUS(HttpStatus.BAD_REQUEST, "이미 적용되었습니다"),
 
 	;
 

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -3,6 +3,7 @@ package com.kt.controller.product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -57,6 +58,12 @@ public class AdminProductController {
 	public ApiResult<Void> updateCategory(@PathVariable("productId") Long productId, @RequestBody
 		ProductUpdateCategoryRequest request) {
 		productService.updateProductCategory(productId, request);
+		return ApiResult.ok();
+	}
+
+	@PatchMapping("/{productId}/toggle-sold-out")
+	public ApiResult<Void> soldOut(@PathVariable("productId") Long productId) {
+		productService.updateProductSoldOut(productId);
 		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.response.ApiResult;
 import com.kt.dto.product.request.ProductCreateRequest;
+import com.kt.dto.product.request.ProductUpdateSoldOutReqeust;
 import com.kt.dto.product.response.ProductListResponse;
 import com.kt.dto.product.response.ProductResponse;
 import com.kt.dto.product.request.ProductUpdateCategoryRequest;
@@ -64,8 +65,8 @@ public class AdminProductController {
 	}
 
 	@PatchMapping("/{productId}/toggle-sold-out")
-	public ApiResult<Void> soldOut(@PathVariable("productId") Long productId) {
-		productService.updateProductSoldOut(productId);
+	public ApiResult<Void> soldOutWithToggle(@PathVariable("productId") Long productId) {
+		productService.updateProductSoldOutWithToggle(productId);
 		return ApiResult.ok();
 	}
 
@@ -78,6 +79,12 @@ public class AdminProductController {
 	@PatchMapping("/{productId}/activate")
 	public ApiResult<Void> activate(@PathVariable("productId") Long productId) {
 		productService.updateProductActive(productId);
+		return ApiResult.ok();
+	}
+
+	@PatchMapping("/sold-out")
+	public ApiResult<Void> soldOut(@RequestBody ProductUpdateSoldOutReqeust request) {
+		productService.updateProductsSoldOut(request);
 		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -2,6 +2,7 @@ package com.kt.controller.product;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +24,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "Product", description = "Product 관리자용 API")
 @RestController
 @RequestMapping("/api/admin/products")

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -66,4 +66,10 @@ public class AdminProductController {
 		productService.updateProductSoldOut(productId);
 		return ApiResult.ok();
 	}
+
+	@PatchMapping("/{productId}/in-activate")
+	public ApiResult<Void> inActivate(@PathVariable("productId") Long productId) {
+		productService.updateProductInActive(productId);
+		return ApiResult.ok();
+	}
 }

--- a/src/main/java/com/kt/controller/product/AdminProductController.java
+++ b/src/main/java/com/kt/controller/product/AdminProductController.java
@@ -55,7 +55,7 @@ public class AdminProductController {
 	}
 
 	@PutMapping("/{productId}/category")
-	public ApiResult<Void> updateCategory(@PathVariable("productId") Long productId, @RequestBody
+	public ApiResult<Void> updateCategory(@PathVariable("productId") Long productId, @Valid @RequestBody
 		ProductUpdateCategoryRequest request) {
 		productService.updateProductCategory(productId, request);
 		return ApiResult.ok();
@@ -70,6 +70,12 @@ public class AdminProductController {
 	@PatchMapping("/{productId}/in-activate")
 	public ApiResult<Void> inActivate(@PathVariable("productId") Long productId) {
 		productService.updateProductInActive(productId);
+		return ApiResult.ok();
+	}
+
+	@PatchMapping("/{productId}/activate")
+	public ApiResult<Void> activate(@PathVariable("productId") Long productId) {
+		productService.updateProductActive(productId);
 		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/domain/product/Product.java
+++ b/src/main/java/com/kt/domain/product/Product.java
@@ -66,4 +66,6 @@ public class Product extends BaseEntity {
 
 	public void updateInActive() {	this.status = ProductStatus.IN_ACTIVATED;  }
 
+	public void updateActive() {  this.status = ProductStatus.ACTIVATED;  }
+
 }

--- a/src/main/java/com/kt/domain/product/Product.java
+++ b/src/main/java/com/kt/domain/product/Product.java
@@ -62,4 +62,8 @@ public class Product extends BaseEntity {
 		this.category = category;
 	}
 
+	public void updateSoldOut() {
+		this.status = ProductStatus.SOLD_OUT;
+	}
+
 }

--- a/src/main/java/com/kt/domain/product/Product.java
+++ b/src/main/java/com/kt/domain/product/Product.java
@@ -62,8 +62,8 @@ public class Product extends BaseEntity {
 		this.category = category;
 	}
 
-	public void updateSoldOut() {
-		this.status = ProductStatus.SOLD_OUT;
-	}
+	public void updateSoldOut() {  this.status = ProductStatus.SOLD_OUT;  }
+
+	public void updateInActive() {	this.status = ProductStatus.IN_ACTIVATED;  }
 
 }

--- a/src/main/java/com/kt/domain/product/ProductStatus.java
+++ b/src/main/java/com/kt/domain/product/ProductStatus.java
@@ -7,10 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ProductStatus {
 
-	ACTIVATED("판매중"),
+	ACTIVATED("판매 중"),
 	SOLD_OUT("품절"),
-	IN_ACTIVATED("판매중지"),
-	DELETED("삭제");
+	IN_ACTIVATED("판매 중지");
 
 	private final String description;
 }

--- a/src/main/java/com/kt/dto/product/request/ProductUpdateSoldOutReqeust.java
+++ b/src/main/java/com/kt/dto/product/request/ProductUpdateSoldOutReqeust.java
@@ -1,0 +1,8 @@
+package com.kt.dto.product.request;
+
+import java.util.List;
+
+public record ProductUpdateSoldOutReqeust(
+	List<Long> productIds
+) {
+}

--- a/src/main/java/com/kt/dto/product/response/ProductResponse.java
+++ b/src/main/java/com/kt/dto/product/response/ProductResponse.java
@@ -7,6 +7,7 @@ public record ProductResponse(
 	String description,
 	Long price,
 	Long stock,
+	String status,
 	String category
 ) {
 	public static ProductResponse from(Product product) {
@@ -15,6 +16,7 @@ public record ProductResponse(
 			product.getDescription(),
 			product.getPrice(),
 			product.getStock(),
+			product.getStatus().getDescription(),
 			product.getCategory().getType()
 		);
 	}

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.common.exception.ErrorCode;
 import com.kt.common.support.ObjectUtils;
+import com.kt.common.support.Preconditions;
 import com.kt.domain.product.Product;
+import com.kt.domain.product.ProductStatus;
 import com.kt.dto.product.request.ProductCreateRequest;
 import com.kt.dto.product.response.ProductListResponse;
 import com.kt.dto.product.response.ProductResponse;
@@ -71,5 +73,14 @@ public class ProductService {
 		product.updateCategory(
 			ObjectUtils.orElse(updateCategory, product.getCategory())
 		);
+	}
+
+
+	public void updateProductSoldOut(Long productId) {
+		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+		Preconditions.validate(!product.getStatus().equals(ProductStatus.SOLD_OUT), ErrorCode.INVALID_PRODUCT_STATUS);
+
+		product.updateSoldOut();
+		//TODO : cart 결제 가능 여부 비활성화 처리
 	}
 }

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -78,9 +78,14 @@ public class ProductService {
 
 	public void updateProductSoldOut(Long productId) {
 		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
-		Preconditions.validate(!product.getStatus().equals(ProductStatus.SOLD_OUT), ErrorCode.INVALID_PRODUCT_STATUS);
 
-		product.updateSoldOut();
+		if (product.getStatus().equals(ProductStatus.SOLD_OUT)) {
+			Preconditions.validate(product.getStock() >= 1, ErrorCode.INVALID_PRODUCT_STOCK);
+			product.updateActive();
+		} else {
+			product.updateSoldOut();
+		}
+
 		//TODO : cart 결제 가능 여부 비활성화 처리
 	}
 
@@ -90,6 +95,7 @@ public class ProductService {
 
 		product.updateInActive();
 	}
+
 
 	public void updateProductActive(Long productId) {
 		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -90,4 +90,11 @@ public class ProductService {
 
 		product.updateInActive();
 	}
+
+	public void updateProductActive(Long productId) {
+		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+		Preconditions.validate(product.getStock() >= 1, ErrorCode.INVALID_PRODUCT_STOCK);
+
+		product.updateActive();
+	}
 }

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -11,6 +11,7 @@ import com.kt.common.support.Preconditions;
 import com.kt.domain.product.Product;
 import com.kt.domain.product.ProductStatus;
 import com.kt.dto.product.request.ProductCreateRequest;
+import com.kt.dto.product.request.ProductUpdateSoldOutReqeust;
 import com.kt.dto.product.response.ProductListResponse;
 import com.kt.dto.product.response.ProductResponse;
 import com.kt.dto.product.request.ProductUpdateCategoryRequest;
@@ -76,7 +77,7 @@ public class ProductService {
 	}
 
 
-	public void updateProductSoldOut(Long productId) {
+	public void updateProductSoldOutWithToggle(Long productId) {
 		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
 
 		if (product.getStatus().equals(ProductStatus.SOLD_OUT)) {
@@ -102,5 +103,15 @@ public class ProductService {
 		Preconditions.validate(product.getStock() >= 1, ErrorCode.INVALID_PRODUCT_STOCK);
 
 		product.updateActive();
+	}
+
+
+	public void updateProductsSoldOut(ProductUpdateSoldOutReqeust request) {
+
+		request.productIds().forEach(productId -> {
+			var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+
+			product.updateSoldOut();
+		});
 	}
 }

--- a/src/main/java/com/kt/service/product/ProductService.java
+++ b/src/main/java/com/kt/service/product/ProductService.java
@@ -83,4 +83,11 @@ public class ProductService {
 		product.updateSoldOut();
 		//TODO : cart 결제 가능 여부 비활성화 처리
 	}
+
+
+	public void updateProductInActive(Long productId) {
+		var product = productRepository.findByIdOrThrow(productId, ErrorCode.NOT_FOUND_PRODUCT);
+
+		product.updateInActive();
+	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #5 


## 🔨변경 사항(Changes)
- product 관리자용 상품 품절(토글) api 개발
- product 관리자용 상품 비활성화 api 개발
- product 관리자용 상품 활성화 api 개발
- product 관리자용 상품 다중 품절 api 개발
- product 관리자용 controller : admin role 검증 로직 추가


## 😉리뷰 요구사항
- 상품 상태 변경 로직에 누락된 검증이 없는지 확인 부탁드립니다.
- 상품 상태 변경을 아래 두 가지 흐름으로 나누어 구현했습니다.
  1. SOLD_OUT ⇄ ACTIVE
  2. INACTIVE ⇄ ACTIVE
해당 흐름을 기준으로 로직을 작성했으니 적절한지 확인 부탁드립니다.
- 재고가 1개 이상이더라도 관리자가 임의로 상품을 품절 처리할 수 있다고 판단하여 SOLD_OUT 전환 시 별도의 재고 검증 로직은 넣지 않았습니다. 이 결정이 적절한지 의견 부탁드립니다

