### PR TITLE
refactor: shopping address 배송 정보 타입에 따른 설명 노출 여부 수정

### DIFF
--- a/src/main/java/com/kt/dto/shoppingaddress/ShoppingAddressListResponse.java
+++ b/src/main/java/com/kt/dto/shoppingaddress/ShoppingAddressListResponse.java
@@ -19,7 +19,7 @@ public record ShoppingAddressListResponse(
 			shoppingAddress.getAddress(),
 			shoppingAddress.getMobile(),
 			shoppingAddress.getInfoType(),
-			shoppingAddress.getInfoDesc(),
+			shoppingAddress.getInfoType().equals(ShoppingAddressType.ETC) ? shoppingAddress.getInfoDesc() : "",
 			shoppingAddress.isDefault()
 		);
 	}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #18


## 🔨변경 사항(Changes)
1. 배송 정보 타입이 ETC 일 경우만 infoDesc 텍스트 노출하도록 변경

## 😉리뷰 요구사항

