### PR TITLE
fix: 장바구니 조회 response dto 수정

### DIFF
--- a/src/main/java/com/kt/domain/cart/Cart.java
+++ b/src/main/java/com/kt/domain/cart/Cart.java
@@ -14,7 +14,7 @@ public class Cart extends BaseEntity {
     @Column(nullable = false)
     private Integer productCount;
 
-    private Long variant;
+    private Long variantId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -24,9 +24,9 @@ public class Cart extends BaseEntity {
     @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
-    public Cart(Integer productCount, Long variant, User user, Product product) {
+    public Cart(Integer productCount, Long variantId, User user, Product product) {
         this.productCount = productCount;
-        this.variant = variant;
+        this.variantId = variantId;
         this.user = user;
         this.product = product;
     }

--- a/src/main/java/com/kt/dto/cart/CartCreateRequest.java
+++ b/src/main/java/com/kt/dto/cart/CartCreateRequest.java
@@ -8,8 +8,8 @@ public record CartCreateRequest(
     @NotNull(message = "상품 수량은 필수 값입니다")
     @Positive(message = "상품 수량은 최소 1개 이상이어야 합니다")
     Integer productCount,
-    @NotBlank(message = "상품 옵션은 필수 값입니다")
-    Long variant,
+    @NotNull(message = "상품 옵션은 필수 값입니다")
+    Long variantId,
 	@NotNull(message = "상품 아이디는 필수 값입니다")
     Long productId
 ){

--- a/src/main/java/com/kt/dto/cart/response/CartResponse.java
+++ b/src/main/java/com/kt/dto/cart/response/CartResponse.java
@@ -5,17 +5,17 @@ import com.kt.domain.cart.Cart;
 public record CartResponse(
 	Long cartId,
 	String name,
-	Long variant,
+	Long variantId,
 	Integer productCount,
-	Long productId
+	Long price
 ) {
 	public static CartResponse from(Cart cart) {
 		return new CartResponse(
 			cart.getId(),
 			cart.getProduct().getName(),
-			cart.getVariant(),
+			cart.getVariantId(),
 			cart.getProductCount(),
-			cart.getProduct().getId()
+			cart.getProduct().getPrice()
 		);
 	}
 }

--- a/src/main/java/com/kt/service/cart/CartService.java
+++ b/src/main/java/com/kt/service/cart/CartService.java
@@ -39,7 +39,7 @@ public class CartService {
 
 		var newCart = new Cart(
 			request.productCount(),
-			request.variant(),
+			request.variantId(),
 			user,
 			product
 		);
@@ -51,6 +51,7 @@ public class CartService {
 
 		return carts.map(CartResponse::from);
 	}
+	//TODO: 유저가 장바구니 여러개 가지고 있을시 N+1 문제 발생 > 추후 수정
 
 	public void updateQuantity(Long cartId, Integer productCount) {
 		Cart cart = cartRepository.findByIdOrThrow(cartId, ErrorCode.NOT_FOUND_CART);


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #9 


## 🔨변경 사항(Changes)
-variant > variantId 로 이름 변경
-오늘 피드백 주신대로 장바구니 조회 시 variantId, cartId, name, price, productCount 만 조회되도록 수정
-장바구니 조회를 했을 때 쿼리가 여러번 찍히는 N+1 문제가 발생했는데, 이 문제는 다른 작업 먼저 완료하고 고치겠습니다!

## 😉리뷰 요구사항


