### PR TITLE
feat: order 목록 조회 개발

### DIFF
--- a/src/main/java/com/kt/controller/cart/CartController.java
+++ b/src/main/java/com/kt/controller/cart/CartController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Cart", description = "장바구니 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/carts")
+@RequestMapping("/api/carts")
 public class CartController extends SwaggerAssistance {
     private final CartService cartService;
 

--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -1,0 +1,19 @@
+package com.kt.controller.order;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.service.order.OrderService;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Order", description = "Order 관리자용 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/orders")
+public class AdminOrderController {
+	private final OrderService orderService;
+}

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -1,19 +1,28 @@
 package com.kt.controller.order;
 
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.dto.order.OrderCreateRequest;
+import com.kt.dto.order.response.OrderListResponse;
 import com.kt.security.CustomUserDetails;
 import com.kt.service.order.OrderService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "Order", description = "주문 관련 API")
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor
@@ -21,9 +30,25 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping("")
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(summary = "주문 생성")
 	public ApiResult<Void> create(@AuthenticationPrincipal CustomUserDetails currentUser,
 		@Valid @RequestBody OrderCreateRequest orderCreateRequest) {
 		orderService.create(currentUser.getId(), orderCreateRequest);
 		return ApiResult.ok();
 	}
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "주문 목록 조회")
+	public ApiResult<Page<OrderListResponse>> getOrderList(
+		Paging paging,
+		@AuthenticationPrincipal CustomUserDetails currentUser
+		) {
+		Page<OrderListResponse> orderList = orderService.getOrderList(currentUser.getId(), paging);
+
+		return ApiResult.ok(orderList);
+	}
+
+
 }

--- a/src/main/java/com/kt/dto/order/response/OrderItemResponse.java
+++ b/src/main/java/com/kt/dto/order/response/OrderItemResponse.java
@@ -1,0 +1,18 @@
+package com.kt.dto.order.response;
+
+import com.kt.domain.orderproduct.OrderProduct;
+
+public record OrderItemResponse(
+	Long id,
+	String name,
+	Long count,
+	Long price
+) { public static OrderItemResponse from(OrderProduct orderProduct) {
+	return new OrderItemResponse(
+		orderProduct.getId(),
+		orderProduct.getProduct().getName(),
+		orderProduct.getCount(),
+		orderProduct.getProduct().getPrice()
+	);
+}
+}

--- a/src/main/java/com/kt/dto/order/response/OrderListResponse.java
+++ b/src/main/java/com/kt/dto/order/response/OrderListResponse.java
@@ -1,0 +1,22 @@
+package com.kt.dto.order.response;
+
+import java.util.List;
+
+import com.kt.domain.order.Order;
+import com.kt.domain.order.OrderStatus;
+
+public record OrderListResponse(
+	Long id,
+	OrderStatus orderStatus,
+	List<OrderItemResponse> items
+) { public static OrderListResponse from(Order order) {
+	return new OrderListResponse(
+		order.getId(),
+		order.getOrderStatus(),
+		order.getOrderProducts()
+			.stream()
+			.map(OrderItemResponse::from)
+			.toList()
+	);
+}
+}

--- a/src/main/java/com/kt/repository/order/OrderRepository.java
+++ b/src/main/java/com/kt/repository/order/OrderRepository.java
@@ -1,8 +1,11 @@
 package com.kt.repository.order;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kt.domain.order.Order;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
+	Page<Order> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -3,15 +3,18 @@ package com.kt.service.order;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.common.exception.ErrorCode;
+import com.kt.common.request.Paging;
 import com.kt.common.support.Preconditions;
 import com.kt.domain.order.Order;
 import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.product.ProductStatus;
 import com.kt.dto.order.OrderCreateRequest;
+import com.kt.dto.order.response.OrderListResponse;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.orderproduct.OrderProductRepository;
 import com.kt.repository.product.ProductRepository;
@@ -73,5 +76,11 @@ public class OrderService {
 		orderRepository.save(newOrder);
 		orderProductRepository.saveAll(orderProducts);
 
+	}
+
+	public Page<OrderListResponse> getOrderList(Long userId, Paging paging) {
+		Page<Order> orderList = orderRepository.findByUserId(userId, paging.toPageable());
+
+		return orderList.map(OrderListResponse::from);
 	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 #50


## 🔨변경 사항(Changes)
-cartController /carts > /api/carts 로 변경
-AdminOrderController 구조 생성
-Order 주문 목록 조회 기능 개발

## 😉리뷰 요구사항
-주문 목록 조회 기능에서 수정 해야 할 부분이 있는지 확인 부탁드립니다!
-철호님이 기능 명세서에 작성해주신 주문 확인은 오더의 상세 정보를 확인하는 기능이라고 하셨는데, 그럼 주문 확인 api 를 따로 만들 필요없이 주문 상세 조회 api 만 만들면 되는 걸까요?

