### PR TITLE
fix: membership 삭제 제약조건 위반 수정

### DIFF
--- a/src/main/java/com/kt/controller/membership/AdminMembershipController.java
+++ b/src/main/java/com/kt/controller/membership/AdminMembershipController.java
@@ -47,11 +47,11 @@ public class AdminMembershipController extends SwaggerAssistance {
 
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResult<Page<MembershipListResponse>> membershipAllList(
+	public ApiResult<Page<MembershipListResponse>> getAllMembership(
 		Paging paging
 	) {
 
-		Page<MembershipListResponse> memberships = membershipService.membershipAllList(paging.toPageable());
+		Page<MembershipListResponse> memberships = membershipService.getAllMembership(paging.toPageable());
 
 		return ApiResult.ok(memberships);
 	}

--- a/src/main/java/com/kt/domain/membership/Membership.java
+++ b/src/main/java/com/kt/domain/membership/Membership.java
@@ -23,18 +23,18 @@ public class Membership {
 	@Column(nullable = false, length = 30)
 	private String level; // BASIC, SILVER, GOLD 등등
 
-	@OneToOne(mappedBy = "membership", cascade = CascadeType.ALL, orphanRemoval = true)
-	private Discount discount;
+	private boolean isDeleted;
 
 	public Membership(String level) {
 			this.level = level;
+			this.isDeleted = false;
 	}
 
 	public void update(String level) {
 		this.level = level;
 	}
 
-	public void changeDiscount(Discount discount) {
-		this.discount = discount;
+	public void delete() {
+		this.isDeleted = true;
 	}
 }

--- a/src/main/java/com/kt/domain/membership/Membership.java
+++ b/src/main/java/com/kt/domain/membership/Membership.java
@@ -1,10 +1,14 @@
 package com.kt.domain.membership;
 
+import com.kt.domain.discount.Discount;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,11 +23,18 @@ public class Membership {
 	@Column(nullable = false, length = 30)
 	private String level; // BASIC, SILVER, GOLD 등등
 
+	@OneToOne(mappedBy = "membership", cascade = CascadeType.ALL, orphanRemoval = true)
+	private Discount discount;
+
 	public Membership(String level) {
 			this.level = level;
 	}
 
 	public void update(String level) {
 		this.level = level;
+	}
+
+	public void changeDiscount(Discount discount) {
+		this.discount = discount;
 	}
 }

--- a/src/main/java/com/kt/repository/membership/MembershipRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/membership/MembershipRepositoryCustom.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import com.kt.dto.membership.MembershipListResponse;
 
 public interface MembershipRepositoryCustom {
-	Page<MembershipListResponse> membershipAllList(Pageable pageable);
+	Page<MembershipListResponse> getAllMembership(Pageable pageable);
 }

--- a/src/main/java/com/kt/repository/membership/MembershipRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/membership/MembershipRepositoryCustomImpl.java
@@ -19,7 +19,7 @@ public class MembershipRepositoryCustomImpl implements  MembershipRepositoryCust
 	private final QMembership membership = QMembership.membership;
 
 	@Override
-	public Page<MembershipListResponse> membershipAllList(Pageable pageable) {
+	public Page<MembershipListResponse> getAllMembership(Pageable pageable) {
 
 		var content = queryFactory
 			.select(new QMembershipListResponse(

--- a/src/main/java/com/kt/service/membership/MembershipService.java
+++ b/src/main/java/com/kt/service/membership/MembershipService.java
@@ -48,7 +48,7 @@ public class MembershipService {
 	public void delete(Long membershipId) {
 		var membership = membershipRepository.findByIdOrThrow(membershipId, ErrorCode.NOT_FOUND_MEMBERSHIP);
 
-		membershipRepository.delete(membership);
+		membership.delete();
 	}
 
 }

--- a/src/main/java/com/kt/service/membership/MembershipService.java
+++ b/src/main/java/com/kt/service/membership/MembershipService.java
@@ -32,9 +32,9 @@ public class MembershipService {
 		membershipRepository.save(membership);
 	}
 
-	public Page<MembershipListResponse> membershipAllList(Pageable pageable) {
+	public Page<MembershipListResponse> getAllMembership(Pageable pageable) {
 
-		return membershipRepositoryCustom.membershipAllList(pageable);
+		return membershipRepositoryCustom.getAllMembership(pageable);
 	}
 
 	public void update(Long membershipId, MembershipUpdateRequest request) {


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #31 


## 🔨변경 사항(Changes)
1. membership 삭제 hard-delete 유지
  - discount와 1:1관계 이므로 casecade 삭제

## 😉리뷰 요구사항
1. membership-discount가 1:1 관계
2. membership 삭제 시 연관된 discount는 필요없음.
3. 이력관리 필요없음.

위의 이유로 soft-delete 하지 않고 연관된 discount까지 같이 삭제되도록 했습니다.

방식에 대해 검토 한번 부탁드리겠습니다.

------------------------------------------------------------------------------------------------------------------
-> 다른 테이블에서도 membership 테이블을 참조하고 있으므로 hard-delete -> soft-delete로 변경