### PR TITLE
feat: 회원탈퇴

### DIFF
--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfiguration {
 
 	private static final String[] GET_PERMIT_ALL = {"/api/health/**", "/swagger-ui/**", "/v3/api-docs/**"};
-	private static final String[] POST_PERMIT_ALL = {"/users/auth/signup", "/users/auth/login"};
+	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login"};
 	private static final String[] PUT_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] PATCH_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] DELETE_PERMIT_ALL = {"/api/v1/public/**"};

--- a/src/main/java/com/kt/controller/user/UserController.java
+++ b/src/main/java/com/kt/controller/user/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;
@@ -56,6 +56,13 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResult<Void> changePassword(@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody UserChangePassword request){
         userService.ChangePassword(userDetails, request);
+        return ApiResult.ok();
+    }
+
+    @DeleteMapping("/withdraw")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResult<Void> withDraw(@AuthenticationPrincipal CustomUserDetails userDetails){
+        userService.WithDraw(userDetails);
         return ApiResult.ok();
     }
 }

--- a/src/main/java/com/kt/repository/user/UserRepository.java
+++ b/src/main/java/com/kt/repository/user/UserRepository.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 
-	Boolean existsByLoginId(String loginId);
-	Optional<User> findByLoginId(String loginId);
+	Boolean existsByLoginIdAndIsDeletedFalse(String loginId);
+	Optional<User> findByLoginIdAndIsDeletedFalse(String loginId);
 
 	@Query("""
 	SELECT exists (SELECT u FROM User u WHERE u.loginId = ?1)

--- a/src/main/java/com/kt/security/CustomUserDetailsService.java
+++ b/src/main/java/com/kt/security/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     // username = loginId 로 사용
     @Override
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
-        User user = userRepository.findByLoginId(loginId)
+        User user = userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         return CustomUserDetails.from(user);

--- a/src/main/java/com/kt/service/user/UserService.java
+++ b/src/main/java/com/kt/service/user/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
     private static final String DEFAULT_MEMBERSHIP_LEVEL = "BRONZE";
 
     public boolean checkLoginIdDuplicated(String loginId) {
-        return userRepository.existsByLoginId(loginId);
+        return userRepository.existsByLoginIdAndIsDeletedFalse(loginId);
     }
 
     public void create(UserCreateRequest request) {
@@ -67,11 +67,13 @@ public class UserService {
     // access토큰 반환 및 기존 리프레시 토큰 삭제및 저장 추가
     @Transactional
     public UserLoginResponse login(UserLoginRequest request) {
-        User user = userRepository.findByLoginId(request.loginId())
+        User user = userRepository.findByLoginIdAndIsDeletedFalse(request.loginId())
                 .orElseThrow(() -> new CustomException(ErrorCode.FAIL_LOGIN));
 
         if(!passwordEncoder.matches(request.password(), user.getPassword())){
             throw new CustomException(ErrorCode.FAIL_LOGIN);
+        }else if(user.isDeleted()){
+            throw new CustomException(ErrorCode.FAIL_LOGIN); // 삭제된 계정이지만 보안을 위해 ID,PASSWORD 로그인실패 처리
         }
 
         String accessToken = jwtTokenProvider.generateAccessToken(user);
@@ -104,7 +106,7 @@ public class UserService {
 
     public UserInfoResponse getMyInfo(CustomUserDetails customUserDetails){
         String loginId = customUserDetails.getUsername();
-        var user = userRepository.findByLoginId(loginId)
+        var user = userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         var shoppingAddressOpt =
@@ -119,7 +121,7 @@ public class UserService {
 
     public void updateMyInfo(CustomUserDetails customUserDetails, UserUpdateRequest request){
         String loginId = customUserDetails.getUsername();
-        var user = userRepository.findByLoginId(loginId)
+        var user = userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
         user.update(
                 orElseIfEmpty(request.name(),user.getName()),
@@ -130,8 +132,15 @@ public class UserService {
 
     public void ChangePassword(CustomUserDetails customUserDetails, UserChangePassword request){
         String loginId = customUserDetails.getUsername();
-        var user = userRepository.findByLoginId(loginId)
+        var user = userRepository.findByLoginIdAndIsDeletedFalse(loginId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
         user.changePassword(passwordEncoder.encode(request.password()));
+    }
+
+    public void WithDraw(CustomUserDetails customUserDetails){
+        String loginId = customUserDetails.getUsername();
+        var user = userRepository.findByLoginIdAndIsDeletedFalse(loginId)
+                .orElseThrow(()->new CustomException(ErrorCode.NOT_FOUND_USER));
+        user.delete();
     }
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #46 


## 🔨변경 사항(Changes)
회원탈퇴 기능 구현 
탈퇴된 계정으로 로그인가능 및 탈퇴된 계정과 중복으로 아이디 생성 불가능 문제 해결
## 😉리뷰 요구사항
탈퇴한 계정 아이디와 중복으로 아이디를 새로 만드는건 어떻게 생각하시는지 탈퇴한 아이디로 로그인할려했을때 보안상 탈퇴한 계정이라고 알려주는게 아니라 아이디/패스워드 이상이라고 throw하는데 어떻게 생각하시는지 궁금합니다
