### PR TITLE
feat: order 주문 수정, 관리자 조회 / 취소 개발

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
 	NOT_ORDER_OWNER(HttpStatus.BAD_REQUEST, "자신의 주문만 취소 할 수 있습니다."),
 	NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST, "해당 주문이 존재하지 않습니다."),
 	CANNOT_CANCEL_ORDER(HttpStatus.BAD_REQUEST, "주문 취소가 불가능합니다."),
+	CANNOT_UPDATE_ORDER_INFO(HttpStatus.BAD_REQUEST, "주문 수정이 불가능합니다."),
 
 	//shoppingaddress
 	NOT_SHOPPING_ADDRESS_OWNER(HttpStatus.FORBIDDEN, "본인의 배송지만 수정/삭제할 수 있습니다."),

--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -1,11 +1,24 @@
 package com.kt.controller.order;
 
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kt.common.request.Paging;
+import com.kt.common.response.ApiResult;
+import com.kt.dto.order.OrderDetailResponse;
+import com.kt.dto.order.response.OrderListResponse;
+import com.kt.security.CustomUserDetails;
 import com.kt.service.order.OrderService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -16,4 +29,34 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/admin/orders")
 public class AdminOrderController {
 	private final OrderService orderService;
+
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "주문 목록 조회")
+	public ApiResult<Page<OrderListResponse>> getOrderList(
+		Paging paging,
+		@AuthenticationPrincipal CustomUserDetails currentUser
+	) {
+		Page<OrderListResponse> orderList = orderService.getOrderList(currentUser.getId(), paging);
+
+		return ApiResult.ok(orderList);
+	}
+
+	@PatchMapping("/{orderId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "주문 취소")
+	public ApiResult<Void> cancel(@PathVariable Long orderId,
+		@AuthenticationPrincipal CustomUserDetails currentUser
+	) {
+		orderService.cancel(orderId, currentUser.getId());
+
+		return ApiResult.ok();
+	}
+
+	@GetMapping("/{orderId}")
+	@Operation(summary = "주문 상세 조회")
+	public ApiResult<OrderDetailResponse> getOrderDetail(@AuthenticationPrincipal CustomUserDetails currentUser,
+		@PathVariable("orderId") Long orderId) {
+		return ApiResult.ok(orderService.getOrderDetail(currentUser.getId(), orderId));
+	}
 }

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -16,6 +16,7 @@ import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.dto.order.OrderCreateRequest;
 import com.kt.dto.order.OrderDetailResponse;
+import com.kt.dto.order.OrderUpdateRequest;
 import com.kt.dto.order.response.OrderListResponse;
 import com.kt.security.CustomUserDetails;
 import com.kt.service.order.OrderService;
@@ -64,10 +65,21 @@ public class OrderController {
 		return ApiResult.ok();
 	}
 
-
 	@GetMapping("/{orderId}")
+	@Operation(summary = "주문 상세 조회")
 	public ApiResult<OrderDetailResponse> getOrderDetail(@AuthenticationPrincipal CustomUserDetails currentUser,
 		@PathVariable("orderId") Long orderId) {
 		return ApiResult.ok(orderService.getOrderDetail(currentUser.getId(), orderId));
+	}
+
+	@PatchMapping("/{orderId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "주문 수정")
+	public ApiResult<Void> update(@RequestBody OrderUpdateRequest request,
+		@PathVariable Long orderId,
+		@AuthenticationPrincipal CustomUserDetails currentUser) {
+		orderService.update(request, orderId, currentUser.getId());
+
+		return ApiResult.ok();
 	}
 }

--- a/src/main/java/com/kt/domain/order/Order.java
+++ b/src/main/java/com/kt/domain/order/Order.java
@@ -60,4 +60,10 @@ public class Order extends BaseEntity {
 		this.isDeleted = true;
 		this.orderStatus = OrderStatus.CANCELLED;
 	}
+
+	public void update(String receiverName, String receiverPhone, String receiverAddress) {
+		this.receiverName = receiverName;
+		this.receiverPhone = receiverPhone;
+		this.receiverAddress = receiverAddress;
+	}
 }

--- a/src/main/java/com/kt/dto/order/OrderUpdateRequest.java
+++ b/src/main/java/com/kt/dto/order/OrderUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.kt.dto.order;
+
+public record OrderUpdateRequest(
+	String receiverName,
+	String receiverPhone,
+	Long receiverAddressId
+) {
+}

--- a/src/main/java/com/kt/repository/shoppingaddress/ShoppingAddressRepository.java
+++ b/src/main/java/com/kt/repository/shoppingaddress/ShoppingAddressRepository.java
@@ -20,4 +20,10 @@ public interface ShoppingAddressRepository extends JpaRepository<ShoppingAddress
 
 	List<ShoppingAddress> findByUserId(Long userId);
 
+	Optional<ShoppingAddress> findByIdAndUserId(Long id, Long userId);
+
+	default ShoppingAddress findByIdAndUserIdOrThrow(Long id, Long userId, ErrorCode errorCode) {
+		return findByIdAndUserId(id, userId).orElseThrow(() -> new CustomException(errorCode));
+	}
+
 }

--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -1,5 +1,7 @@
 package com.kt.service.order;
 
+import static com.kt.common.support.ObjectUtils.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -16,6 +18,7 @@ import com.kt.domain.order.OrderStatus;
 import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.product.ProductStatus;
 import com.kt.dto.order.OrderCreateRequest;
+import com.kt.dto.order.OrderUpdateRequest;
 import com.kt.dto.order.response.OrderListResponse;
 import com.kt.dto.order.OrderDetailResponse;
 import com.kt.dto.order.OrderProductResponse;
@@ -108,7 +111,6 @@ public class OrderService {
 		order.cancel();
 	}
 
-
 	public OrderDetailResponse getOrderDetail(Long userId, Long orderId) {
 		var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
 
@@ -127,5 +129,24 @@ public class OrderService {
 		//TODO: payment 정보 반환
 
 		return OrderDetailResponse.from(order, products);
+	}
+
+	public void update(OrderUpdateRequest request, Long orderId, Long userId) {
+		var order = orderRepository.findByIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+
+		Preconditions.validate(order.getUser().getId().equals(userId), ErrorCode.NOT_ORDER_OWNER);
+
+		Preconditions.validate(order.getOrderStatus() == OrderStatus.ORDERED ||
+			order.getOrderStatus() == OrderStatus.PAID, ErrorCode.CANNOT_UPDATE_ORDER_INFO);
+
+		String updatedAddress = request.receiverAddressId() != null
+			? shoppingAddressRepository.findByIdOrThrow(request.receiverAddressId(), ErrorCode.NOT_FOUND_SHOPPING_ADDRESS).getAddress()
+			: order.getReceiverAddress();
+
+		order.update(
+			orElseIfEmpty(request.receiverName(), order.getReceiverName()),
+			orElseIfEmpty(request.receiverPhone(), order.getReceiverPhone()),
+			updatedAddress
+		);
 	}
 }

--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -140,7 +140,7 @@ public class OrderService {
 			order.getOrderStatus() == OrderStatus.PAID, ErrorCode.CANNOT_UPDATE_ORDER_INFO);
 
 		String updatedAddress = request.receiverAddressId() != null
-			? shoppingAddressRepository.findByIdOrThrow(request.receiverAddressId(), ErrorCode.NOT_FOUND_SHOPPING_ADDRESS).getAddress()
+			? shoppingAddressRepository.findByIdAndUserIdOrThrow(request.receiverAddressId(), userId, ErrorCode.NOT_SHOPPING_ADDRESS_OWNER).getAddress()
 			: order.getReceiverAddress();
 
 		order.update(


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #50


## 🔨변경 사항(Changes)
-ErrorCode 추가
-OrderUpdateRequest DTO 추가
-Order 도메인에 update 추가
-addressId 가 user 본인이 수정한 것인지 검증 로직 추가 (shoppingAddressRepository 에 메서드 추가)
-AdminOrderController 주문 목록 조회, 주문 상세 조회, 주문 취소 추가

## 😉리뷰 요구사항
-검증 로직이 잘 작성 되었는지 확인 부탁드립니다!
-저희가 정한 API 명세서에는 관리자 주문 목록 조회는 없고 상세 조회만 있는데 철호님이 작성해주신 기능 명세서에는 목록 조회가 있어서 우선 이거도 추가했습니다! 주문 목록으로 들어가서 상세 조회나 취소같은 세부적인 작업을 할 수 있다고 생각했습니다

