### PR TITLE
feat: payment 결제 기록 생성

### DIFF
--- a/src/main/java/com/kt/controller/payment/PaymentController.java
+++ b/src/main/java/com/kt/controller/payment/PaymentController.java
@@ -1,7 +1,11 @@
 package com.kt.controller.payment;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.response.ApiResult;
 import com.kt.dto.payment.PaymentCreateRequest;
@@ -10,14 +14,13 @@ import com.kt.service.payment.PaymentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/payments")
 public class PaymentController {
 
-	private final PaymentService paymentService;
+	// private final PaymentService paymentService;
 
-	@PostMapping
-	public ApiResult<Void> create(PaymentCreateRequest request) {
-		paymentService.create(request);
-	}
+
 }
+

--- a/src/main/java/com/kt/controller/payment/PaymentController.java
+++ b/src/main/java/com/kt/controller/payment/PaymentController.java
@@ -1,0 +1,23 @@
+package com.kt.controller.payment;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.kt.common.response.ApiResult;
+import com.kt.dto.payment.PaymentCreateRequest;
+import com.kt.service.payment.PaymentService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+	private final PaymentService paymentService;
+
+	@PostMapping
+	public ApiResult<Void> create(PaymentCreateRequest request) {
+		paymentService.create(request);
+	}
+}

--- a/src/main/java/com/kt/domain/payment/Payment.java
+++ b/src/main/java/com/kt/domain/payment/Payment.java
@@ -2,6 +2,7 @@ package com.kt.domain.payment;
 
 import com.kt.common.support.BaseEntity;
 import com.kt.domain.order.Order;
+import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.paymenttype.PaymentType;
 
 import jakarta.persistence.*;
@@ -19,13 +20,13 @@ public class Payment extends BaseEntity {
 	private Long id;
 
 	@Column(nullable = false)
-	private Integer totalPrice;
+	private Integer totalPrice;    // 총 상품 금액
 
 	@Column(nullable = false)
-	private Integer deliveryFee;
+	private Integer deliveryFee;   // 배송비
 
 	@Column(nullable = false)
-	private Integer finalPrice;
+	private Integer finalPrice;    // 총 결제 금액 (상품금액 + 배송비)
 
 	@Column(nullable = false)
 	private boolean isDeleted = false;
@@ -40,20 +41,16 @@ public class Payment extends BaseEntity {
 
 	public Payment(
 		Order order,
+		PaymentType paymentType,
 		Integer totalPrice,
 		Integer deliveryFee,
-		Integer finalPrice,
-		PaymentType paymentType
+		Integer finalPrice
 	) {
 		this.order = order;
+		this.paymentType = paymentType;
 		this.totalPrice = totalPrice;
 		this.deliveryFee = deliveryFee;
 		this.finalPrice = finalPrice;
-		this.paymentType = paymentType;
 		this.isDeleted = false;
-	}
-
-	public void delete() {
-		this.isDeleted = true;
 	}
 }

--- a/src/main/java/com/kt/dto/payment/PaymentCreateRequest.java
+++ b/src/main/java/com/kt/dto/payment/PaymentCreateRequest.java
@@ -1,4 +1,13 @@
 package com.kt.dto.payment;
 
-public record PaymentCreateRequest() {
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentCreateRequest(
+	@NotNull(message = "주문 ID는 필수입니다")
+	Long orderId,
+
+	@NotNull(message = "결제수단 ID은 필수입니다")
+	Long paymentTypeId
+) {
+
 }

--- a/src/main/java/com/kt/dto/payment/PaymentCreateRequest.java
+++ b/src/main/java/com/kt/dto/payment/PaymentCreateRequest.java
@@ -1,0 +1,4 @@
+package com.kt.dto.payment;
+
+public record PaymentCreateRequest() {
+}

--- a/src/main/java/com/kt/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/service/payment/PaymentService.java
@@ -1,7 +1,45 @@
 package com.kt.service.payment;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.domain.payment.Payment;
+import com.kt.dto.payment.PaymentCreateRequest;
+import com.kt.repository.order.OrderRepository;
+import com.kt.repository.payment.PaymentRepository;
+import com.kt.repository.paymenttype.PaymentTypeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class PaymentService {
 
+	private final PaymentRepository paymentRepository;
+	private final OrderRepository orderRepository;
+	private final PaymentTypeRepository paymentTypeRepository;
 
-	public void create
+
+	@Transactional
+	public void create(PaymentCreateRequest request) {
+
+		var order = orderRepository.findById(request.orderId())
+			.orElseThrow();
+
+		var paymentType = paymentTypeRepository.findById(request.paymentTypeId())
+			.orElseThrow();
+
+		int total = order.getOrderProducts().stream()
+			.mapToInt(orderproduct -> (int) (orderproduct.getProduct().getPrice() * orderproduct.getCount()))
+			.sum();
+
+		int delivery = 3000;
+
+		int finalPrice = total + delivery;
+
+		var payment = new Payment(order, paymentType, total, delivery, finalPrice);
+
+		paymentRepository.save(payment);
+	}
+
 }

--- a/src/main/java/com/kt/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/service/payment/PaymentService.java
@@ -1,0 +1,7 @@
+package com.kt.service.payment;
+
+public class PaymentService {
+
+
+	public void create
+}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #8


## 🔨변경 사항(Changes)
결제 생성 로직은 Order 결제완료 상태 변경 시 내부적으로 호출되는 구조로 알고
PaymentController는 테스트용으로만 사용했기 때문에 PR에서는 틀만 남겨놓고 제외했습니다!

PaymentService.create(), Payment 엔티티, DTO 등 실제 도메인 로직만 포함합니다.

## 😉리뷰 요구사항
오류가 없는지 확인부탁드립니다!!