### PR TITLE
feat: order 관리자 주문 취소, cart 수량 변경 로직 수정

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -71,6 +71,7 @@ public enum ErrorCode {
 
 	//cart
 	NOT_FOUND_CART(HttpStatus.BAD_REQUEST, "해당 장바구니를 찾을 수 없습니다."),
+	NOT_CART_OWNER(HttpStatus.BAD_REQUEST, "본인의 장바구니만 수정 할 수 있습니다."),
 
 	//order product
 	NOT_FOUND_ORDER_PRODUCT(HttpStatus.BAD_REQUEST, "주문 상품을 찾을 수 없습니다."),

--- a/src/main/java/com/kt/controller/cart/CartController.java
+++ b/src/main/java/com/kt/controller/cart/CartController.java
@@ -52,8 +52,9 @@ public class CartController extends SwaggerAssistance {
     @Operation(summary = "장바구니 수량 변경")
     public ApiResult<Void> updateQuantity(
             @Valid @RequestBody CartUpdateQuantityRequest request,
-            @PathVariable Long cartId) {
-        cartService.updateQuantity(cartId, request.productCount());
+            @PathVariable Long cartId,
+		@AuthenticationPrincipal CustomUserDetails currentUser) {
+        cartService.updateQuantity(cartId, currentUser.getId(), request.productCount());
 
         return ApiResult.ok();
     }

--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -42,13 +42,12 @@ public class AdminOrderController {
 		return ApiResult.ok(orderList);
 	}
 
-	@PatchMapping("/{orderId}")
+	@PatchMapping("/{orderId}/cancel")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 취소")
-	public ApiResult<Void> cancel(@PathVariable Long orderId,
-		@AuthenticationPrincipal CustomUserDetails currentUser
+	public ApiResult<Void> cancel(@PathVariable Long orderId
 	) {
-		orderService.cancel(orderId, currentUser.getId());
+		orderService.cancelByAdmin(orderId);
 
 		return ApiResult.ok();
 	}

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -54,7 +54,7 @@ public class OrderController {
 		return ApiResult.ok(orderList);
 	}
 
-	@PatchMapping("/{orderId}")
+	@PatchMapping("/{orderId}/cancel")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 취소")
 	public ApiResult<Void> cancel(@PathVariable Long orderId,
@@ -82,4 +82,5 @@ public class OrderController {
 
 		return ApiResult.ok();
 	}
+
 }

--- a/src/main/java/com/kt/service/cart/CartService.java
+++ b/src/main/java/com/kt/service/cart/CartService.java
@@ -77,9 +77,12 @@ public class CartService {
 		));
 	}
 
-	public void updateQuantity(Long cartId, Integer productCount) {
+	public void updateQuantity(Long cartId, Long userId, Integer productCount) {
 		Cart cart = cartRepository.findByIdOrThrow(cartId, ErrorCode.NOT_FOUND_CART);
 		Product product = productRepository.findByIdOrThrow(cart.getProduct().getId(), ErrorCode.NOT_FOUND_PRODUCT);
+
+		// 변경할 장바구니가 유저 본인 장바구니인지 확인
+		Preconditions.validate(cart.getUser().getId().equals(userId), ErrorCode.NOT_CART_OWNER);
 
 		// 변경할 수량이 상품의 재고보다 적은지 확인
 		Preconditions.validate(productCount <= product.getStock(),ErrorCode.NOT_ENOUGH_STOCK);

--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -149,4 +149,14 @@ public class OrderService {
 			updatedAddress
 		);
 	}
+
+	public void cancelByAdmin(Long orderId) {
+		var order = orderRepository.findByIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
+
+		// 주문 취소 가능 여부 검증
+		Preconditions.validate(order.getOrderStatus() == OrderStatus.ORDERED ||
+			order.getOrderStatus() == OrderStatus.PAID, ErrorCode.CANNOT_CANCEL_ORDER);
+
+		order.cancel();
+	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-cart 장바구니 수량 변경 시 장바구니가 갖고있는 user id 랑 user 엔티티의 id 와 같은지 검증 로직 추가했습니다
-AdminOrderController 관리자는 userId 를 받을 필요가 없으니 관리자용 주문 취소 메서드 따로 추가했습니다
-주문 취소 api > /orders/{orderId}/cancel 로 수정했습니다

## 😉리뷰 요구사항
로직들이 잘 작성 되어 있는지 확인 부탁드립니다!
