### PR TITLE
fix: order updateStatus 에서 PAID 삭제

### DIFF
--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -199,8 +199,6 @@ public class OrderService {
 		var order = orderRepository.findByIdOrThrow(orderId, ErrorCode.NOT_FOUND_ORDER);
 
 		switch (request.orderStatus()) {
-			case PAID -> Preconditions.validate(order.getOrderStatus() == OrderStatus.ORDERED,
-				ErrorCode.CANNOT_UPDATE_ORDER_STATUS);
 			case PROCESSING -> Preconditions.validate(order.getOrderStatus() == OrderStatus.PAID,
 				ErrorCode.CANNOT_UPDATE_ORDER_STATUS);
 			case SHIPPED -> Preconditions.validate(order.getOrderStatus() == OrderStatus.PROCESSING,


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #50


## 🔨변경 사항(Changes)
-Order 의 상태값을 변경하는 updateStatus 에서 PAID 삭제 (order 생성 시 payment 생성을 하면서 상태값을 PAID 로 변경하기에 PAID 로 변경하는 로직은 삭제했습니다)


## 😉리뷰 요구사항

