### PR TITLE
fix: cart 장바구니 수량 변경시 가격 변경 로직 추가, cartResponse 에 productId 추가, order Swagger 상속

### DIFF
--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
+import com.kt.common.support.SwaggerAssistance;
 import com.kt.dto.order.OrderDetailResponse;
 import com.kt.dto.order.OrderStatusUpdateRequest;
 import com.kt.dto.order.response.OrderListResponse;
@@ -28,7 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/orders")
-public class AdminOrderController {
+public class AdminOrderController extends SwaggerAssistance {
 	private final OrderService orderService;
 
 	@GetMapping

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
+import com.kt.common.support.SwaggerAssistance;
 import com.kt.dto.order.OrderCreateRequest;
 import com.kt.dto.order.OrderDetailResponse;
 import com.kt.dto.order.OrderUpdateRequest;
@@ -30,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor
-public class OrderController {
+public class OrderController extends SwaggerAssistance {
 	private final OrderService orderService;
 
 	@PostMapping("")

--- a/src/main/java/com/kt/domain/cart/Cart.java
+++ b/src/main/java/com/kt/domain/cart/Cart.java
@@ -16,6 +16,8 @@ public class Cart extends BaseEntity {
 
     private Long variantId;
 
+	private Long totalPrice;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -33,5 +35,6 @@ public class Cart extends BaseEntity {
 
 	public void updateQuantity(Integer productCount) {
 		this.productCount = productCount;
+		this.totalPrice = this.product.getPrice() * productCount;
 	}
 }

--- a/src/main/java/com/kt/dto/cart/response/CartResponse.java
+++ b/src/main/java/com/kt/dto/cart/response/CartResponse.java
@@ -6,8 +6,10 @@ public record CartResponse(
 	Long cartId,
 	String name,
 	Long variantId,
+	Long productId,
 	Integer productCount,
 	Long price, // 원가
+	Long totalPrice, // 변경된 수량이 적용된 금액
 	Long discountAmount, // 할인 금액
 	Long discountedPrice // 할인된 최종 금액
 ) {
@@ -16,8 +18,10 @@ public record CartResponse(
 			cart.getId(),
 			cart.getProduct().getName(),
 			cart.getVariantId(),
+			cart.getProduct().getId(),
 			cart.getProductCount(),
 			cart.getProduct().getPrice(),
+			cart.getTotalPrice(),
 			discountAmount,
 			discountedPrice
 		);


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-Cart 장바구니 수량 변경 시 가격 변경 로직을 도메인에 추가 (updateQuantity 메서드에서 수량이 변경되면 가격도 변경되도록 설정했습니다)
-Cart 도메인에 totalPrice (수량 변경 적용된 가격) 필드 추가
-cartResponse 에 장바구니를 통해 주문하는 경우 고려해서 ProductId 추가, totalPrice 도 조회하도록 추가
-OrderController (user, admin) 에 Swagger 상속

## 😉리뷰 요구사항
잘 작성되어 있는지 검토 부탁드립니다!

