### PR TITLE
fix: cart, order response dto 수정

### DIFF
--- a/src/main/java/com/kt/common/response/ApiResult.java
+++ b/src/main/java/com/kt/common/response/ApiResult.java
@@ -28,6 +28,10 @@ public class ApiResult<T> {
 		return ApiResult.of(code, message, null, LocalDateTime.now());
 	}
 
+	public static <T> ApiResult<T> of(String message, T data) {
+		return ApiResult.of("ok", message, data, LocalDateTime.now());
+	}
+
 	private static <T> ApiResult<T> of(String code, String message, T data,  LocalDateTime timestamp) {
 		return new ApiResult<>(code, message, data, timestamp);
 	}

--- a/src/main/java/com/kt/controller/cart/CartController.java
+++ b/src/main/java/com/kt/controller/cart/CartController.java
@@ -25,16 +25,16 @@ import org.springframework.web.bind.annotation.*;
 public class CartController extends SwaggerAssistance {
     private final CartService cartService;
 
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "장바구니 생성")
-    public ApiResult<Void> create(
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	@Operation(summary = "장바구니 생성")
+	public ApiResult<Long> create(
 		@AuthenticationPrincipal CustomUserDetails currentUser,
 		@Valid @RequestBody CartCreateRequest request) {
-        cartService.create(currentUser.getId(), request);
+		Long cartId = cartService.create(currentUser.getId(), request);
 
-        return ApiResult.ok();
-    }
+		return ApiResult.of("장바구니 생성 완료", cartId);
+	}
 
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
@@ -47,33 +47,33 @@ public class CartController extends SwaggerAssistance {
 		return ApiResult.ok(carts);
 	}
 
-    @PatchMapping("/{cartId}")
-    @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "장바구니 수량 변경")
-    public ApiResult<Void> updateQuantity(
-            @Valid @RequestBody CartUpdateQuantityRequest request,
-            @PathVariable Long cartId,
+	@PatchMapping("/{cartId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "장바구니 수량 변경")
+	public ApiResult<Long> updateQuantity(
+		@Valid @RequestBody CartUpdateQuantityRequest request,
+		@PathVariable Long cartId,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
-        cartService.updateQuantity(cartId, currentUser.getId(), request.productCount());
+		cartService.updateQuantity(cartId, currentUser.getId(), request.productCount());
 
-        return ApiResult.ok();
-    }
+		return ApiResult.of("장바구니 상품 수량 변경 완료", cartId);
+	}
 
-    @DeleteMapping("/{cartId}")
-    @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "장바구니에서 특정 상품 삭제")
-    public ApiResult<Void> deleteCartItem(@PathVariable Long cartId) {
-        cartService.deleteCartItem(cartId);
+	@DeleteMapping("/{cartId}")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "장바구니에서 특정 상품 삭제")
+	public ApiResult<Long> deleteCartItem(@PathVariable Long cartId) {
+		cartService.deleteCartItem(cartId);
 
-        return ApiResult.ok();
-    }
+		return ApiResult.of("장바구니 삭제 완료", cartId);
+	}
 
-    @DeleteMapping
-    @ResponseStatus(HttpStatus.OK)
-    @Operation(summary = "장바구니 전체 삭제")
-    public ApiResult<Void> clearCart(@AuthenticationPrincipal CustomUserDetails currentUser) {
-        cartService.clearCart(currentUser.getId());
+	@DeleteMapping
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "장바구니 전체 삭제")
+	public ApiResult<Void> clearCart(@AuthenticationPrincipal CustomUserDetails currentUser) {
+		cartService.clearCart(currentUser.getId());
 
-        return ApiResult.ok();
-    }
+		return ApiResult.ok();
+	}
 }

--- a/src/main/java/com/kt/controller/order/AdminOrderController.java
+++ b/src/main/java/com/kt/controller/order/AdminOrderController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.common.support.SwaggerAssistance;
-import com.kt.dto.order.OrderDetailResponse;
+import com.kt.dto.order.response.OrderDetailResponse;
 import com.kt.dto.order.OrderStatusUpdateRequest;
 import com.kt.dto.order.response.OrderListResponse;
 import com.kt.security.CustomUserDetails;
@@ -47,11 +47,11 @@ public class AdminOrderController extends SwaggerAssistance {
 	@PatchMapping("/{orderId}/cancel")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 취소")
-	public ApiResult<Void> cancel(@PathVariable Long orderId
+	public ApiResult<Long> cancel(@PathVariable Long orderId
 	) {
 		orderService.cancelByAdmin(orderId);
 
-		return ApiResult.ok();
+		return ApiResult.of("주문 취소 완료", orderId);
 	}
 
 	@GetMapping("/{orderId}")
@@ -65,31 +65,28 @@ public class AdminOrderController extends SwaggerAssistance {
 	@PatchMapping("/{orderId}/refund-approve")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 환불 승인")
-	public ApiResult<Void> approveRefund(@PathVariable Long orderId) {
+	public ApiResult<Long> approveRefund(@PathVariable Long orderId) {
 		orderService.approveRefund(orderId);
 
-		return ApiResult.ok();
+		return ApiResult.of("환불 승인 완료", orderId);
 	}
 
 	@PatchMapping("/{orderId}/return-approve")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 반품 승인")
-	public ApiResult<Void> approveReturn(@PathVariable Long orderId) {
+	public ApiResult<Long> approveReturn(@PathVariable Long orderId) {
 		orderService.approveReturn(orderId);
 
-		return ApiResult.ok();
+		return ApiResult.of("반품 승인 완료", orderId);
 	}
 
 	@PatchMapping("/{orderId}/status")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 상태 변경")
-	public ApiResult<Void> updateStatus(OrderStatusUpdateRequest request,
+	public ApiResult<Long> updateStatus(OrderStatusUpdateRequest request,
 		@PathVariable Long orderId) {
 		orderService.updateStatus(request, orderId);
 
-		return ApiResult.ok();
+		return ApiResult.of("주문 상태 업데이트 완료", orderId);
 	}
-
-
-
 }

--- a/src/main/java/com/kt/controller/order/OrderController.java
+++ b/src/main/java/com/kt/controller/order/OrderController.java
@@ -16,7 +16,7 @@ import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.common.support.SwaggerAssistance;
 import com.kt.dto.order.OrderCreateRequest;
-import com.kt.dto.order.OrderDetailResponse;
+import com.kt.dto.order.response.OrderDetailResponse;
 import com.kt.dto.order.OrderUpdateRequest;
 import com.kt.dto.order.response.OrderListResponse;
 import com.kt.security.CustomUserDetails;
@@ -37,10 +37,10 @@ public class OrderController extends SwaggerAssistance {
 	@PostMapping("")
 	@ResponseStatus(HttpStatus.CREATED)
 	@Operation(summary = "주문 생성")
-	public ApiResult<Void> create(@AuthenticationPrincipal CustomUserDetails currentUser,
+	public ApiResult<Long> create(@AuthenticationPrincipal CustomUserDetails currentUser,
 		@Valid @RequestBody OrderCreateRequest orderCreateRequest) {
-		orderService.create(currentUser.getId(), orderCreateRequest);
-		return ApiResult.ok();
+		Long orderId = orderService.create(currentUser.getId(), orderCreateRequest);
+		return ApiResult.of("주문 생성 완료", orderId);
 	}
 
 	@GetMapping
@@ -49,7 +49,7 @@ public class OrderController extends SwaggerAssistance {
 	public ApiResult<Page<OrderListResponse>> getOrderList(
 		@Valid Paging paging,
 		@AuthenticationPrincipal CustomUserDetails currentUser
-		) {
+	) {
 		Page<OrderListResponse> orderList = orderService.getOrderList(currentUser.getId(), paging);
 
 		return ApiResult.ok(orderList);
@@ -58,12 +58,12 @@ public class OrderController extends SwaggerAssistance {
 	@PatchMapping("/{orderId}/cancel")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 취소")
-	public ApiResult<Void> cancel(@PathVariable Long orderId,
+	public ApiResult<Long> cancel(@PathVariable Long orderId,
 		@AuthenticationPrincipal CustomUserDetails currentUser
 	) {
 		orderService.cancel(orderId, currentUser.getId());
 
-		return ApiResult.ok();
+		return ApiResult.of("주문 취소 완료", orderId);
 	}
 
 	@GetMapping("/{orderId}")
@@ -76,34 +76,31 @@ public class OrderController extends SwaggerAssistance {
 	@PatchMapping("/{orderId}")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 수정")
-	public ApiResult<Void> update(@RequestBody OrderUpdateRequest request,
+	public ApiResult<Long> update(@RequestBody OrderUpdateRequest request,
 		@PathVariable Long orderId,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
 		orderService.update(request, orderId, currentUser.getId());
 
-		return ApiResult.ok();
+		return ApiResult.of("주문 수정 완료", orderId);
 	}
 
 	@PatchMapping("/{orderId}/refund-request")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 환불 요청")
-	public ApiResult<Void> requestRefund(@PathVariable Long orderId,
+	public ApiResult<Long> requestRefund(@PathVariable Long orderId,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
 		orderService.requestRefund(orderId, currentUser.getId());
 
-		return ApiResult.ok();
+		return ApiResult.of("환불 요청 완료", orderId);
 	}
 
 	@PatchMapping("/{orderId}/return-request")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "주문 반품 요청")
-	public ApiResult<Void> requestReturn(@PathVariable Long orderId,
+	public ApiResult<Long> requestReturn(@PathVariable Long orderId,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
 		orderService.requestReturn(orderId, currentUser.getId());
 
-		return ApiResult.ok();
+		return ApiResult.of("반품 요청 완료", orderId);
 	}
-
-
-
 }

--- a/src/main/java/com/kt/dto/order/response/OrderDetailResponse.java
+++ b/src/main/java/com/kt/dto/order/response/OrderDetailResponse.java
@@ -1,11 +1,10 @@
-package com.kt.dto.order;
+package com.kt.dto.order.response;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import com.kt.domain.order.Order;
 import com.kt.domain.order.OrderStatus;
-import com.kt.domain.payment.Payment;
 
 public record OrderDetailResponse(
 	OrderStatus orderStatus,

--- a/src/main/java/com/kt/dto/order/response/OrderProductResponse.java
+++ b/src/main/java/com/kt/dto/order/response/OrderProductResponse.java
@@ -1,4 +1,4 @@
-package com.kt.dto.order;
+package com.kt.dto.order.response;
 
 import com.kt.domain.discount.Discount;
 import com.kt.domain.orderproduct.OrderProduct;

--- a/src/main/java/com/kt/service/cart/CartService.java
+++ b/src/main/java/com/kt/service/cart/CartService.java
@@ -35,7 +35,7 @@ public class CartService {
 	private final DiscountRepository discountRepository;
 	private final VariantRepository variantRepository;
 
-    public void create(Long userId, CartCreateRequest request) {
+    public Long create(Long userId, CartCreateRequest request) {
 		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
 		var product = productRepository.findByIdOrThrow(request.productId(), ErrorCode.NOT_FOUND_PRODUCT);
 
@@ -55,6 +55,8 @@ public class CartService {
 			product
 		);
 		cartRepository.save(newCart);
+
+		return newCart.getId();
     }
 
 	public Page<CartResponse> getCartList(Long userId, Paging paging) {

--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -26,8 +26,8 @@ import com.kt.dto.order.OrderCreateRequest;
 import com.kt.dto.order.OrderStatusUpdateRequest;
 import com.kt.dto.order.OrderUpdateRequest;
 import com.kt.dto.order.response.OrderListResponse;
-import com.kt.dto.order.OrderDetailResponse;
-import com.kt.dto.order.OrderProductResponse;
+import com.kt.dto.order.response.OrderDetailResponse;
+import com.kt.dto.order.response.OrderProductResponse;
 import com.kt.repository.discount.DiscountRepository;
 import com.kt.repository.order.OrderRepository;
 import com.kt.repository.order.OrderRepositoryCustom;
@@ -52,7 +52,7 @@ public class OrderService {
 	private final DiscountRepository discountRepository;
 	private final OrderRepositoryCustom orderRepositoryCustom;
 
-	public void create(Long userId, OrderCreateRequest request) {
+	public Long create(Long userId, OrderCreateRequest request) {
 		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
 		var address = shoppingAddressRepository.findByIdOrThrow(request.receiverAddressId(), ErrorCode.NOT_FOUND_SHOPPING_ADDRESS);
 
@@ -97,6 +97,7 @@ public class OrderService {
 		orderRepository.save(newOrder);
 		orderProductRepository.saveAll(orderProducts);
 
+		return newOrder.getId();
 	}
 
 	public Page<OrderListResponse> getOrderList(Long userId, Paging paging) {


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-ApiResult 메서드 추가
-cart, order 조회 제외한 API 들의 반환값으로 API 행위와 관련된 메세지, cartId / orderId 반환하도록 수정
-orderDetailResponse, orderProductResponse 를 /dto/order/response 로 이동

## 😉리뷰 요구사항

