### PR TITLE
feat: 운영 환경 분리 local, dev, prod

### DIFF
--- a/src/main/java/com/kt/common/profile/AppProfile.java
+++ b/src/main/java/com/kt/common/profile/AppProfile.java
@@ -6,6 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import org.springframework.context.annotation.Profile;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Profile({"local"})
-public @interface LocalProfile {
+@Profile("prod")
+public @interface AppProfile {
 }

--- a/src/main/java/com/kt/common/profile/DevProfile.java
+++ b/src/main/java/com/kt/common/profile/DevProfile.java
@@ -6,6 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 import org.springframework.context.annotation.Profile;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Profile({"local"})
-public @interface LocalProfile {
+@Profile("dev")
+public @interface DevProfile {
 }

--- a/src/main/java/com/kt/config/RedisConfiguration.java
+++ b/src/main/java/com/kt/config/RedisConfiguration.java
@@ -8,6 +8,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import lombok.RequiredArgsConstructor;
+
+import com.kt.common.profile.AppProfile;
+import com.kt.common.profile.DevProfile;
 import com.kt.common.profile.LocalProfile;
 
 @Configuration
@@ -16,6 +19,7 @@ public class RedisConfiguration {
 	private final RedisProperties redisProperties;
 
 	@Bean
+	@AppProfile
 	public RedissonClient redissonClient() {
 		var config = new Config();
 		var host = redisProperties.getCluster().getNodes().getFirst();
@@ -29,11 +33,39 @@ public class RedisConfiguration {
 	}
 
 	@Bean
+	@DevProfile
+	public RedissonClient devRedissonClient() {
+		var config = new Config();
+
+		String host = redisProperties.getHost() + ":" + redisProperties.getPort();
+
+		if(redisProperties.getCluster() != null &&
+			redisProperties.getCluster().getNodes() != null &&
+		!redisProperties.getCluster().getNodes().isEmpty()) {
+			host = redisProperties.getCluster().getNodes().getFirst();
+		}
+
+		boolean isSSL = redisProperties.getSsl() != null
+			&& redisProperties.getSsl().isEnabled();
+
+		var protocol = isSSL ? "rediss" : "redis";
+		var uri = String.format("%s://%s", protocol, host);
+
+		config
+			.useSingleServer()
+			.setAddress(uri);
+
+		return Redisson.create(config);
+	}
+
+	@Bean
 	@LocalProfile
 	public RedissonClient localRedissonClient() {
 		var config = new Config();
-		var host = redisProperties.getCluster().getNodes().getFirst();
-		var uri = String.format("rediss://%s", host);
+
+		var host = redisProperties.getHost();
+		var port = redisProperties.getPort();
+		var uri = String.format("redis://%s:%s", host, port);
 
 		config
 			.useSingleServer()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${db.host:localhost}:3306/${db.scheme:shopping}
+    username: ${db.username:root}
+    password: ${db.password:1234}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    show-sql: true
+  data:
+    redis:
+      ssl:
+        enabled: true
+      cluster:
+        nodes: ${redis.host:localhost:6379}
+        max-redirects: 3
+
+jwt:
+  secret: ${kt.jwt.secret:kt-cloud-tech-up-shopping-202511171107}
+  access-token-expiration: ${kt.jwt.access-token-expiration:300000}
+  refresh-token-expiration: ${kt.jwt.refresh-token-expiration:43200000}
+
+server:
+  port: ${shopping.server.port:8080}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/shopping
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+    show-sql: true
+  data:
+    redis:
+        host: localhost
+        port: 6379
+        ssl:
+          enabled: false
+jwt:
+  secret: kt-cloud-tech-up-shopping-202511171107
+  access-token-expiration: 300000
+  refresh-token-expiration: 43200000
+
+server:
+  port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,27 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${db.host}:3306/${db.scheme}
+    username: ${db.username}
+    password: ${db.password}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+    show-sql: false
+  data:
+    redis:
+      ssl:
+        enabled: true
+      cluster:
+        nodes: ${redis.host}
+        max-redirects: 3
+
+jwt:
+  secret: ${kt.jwt.secret}
+  access-token-expiration: ${kt.jwt.access-token-expiration}
+  refresh-token-expiration: ${kt.jwt.refresh-token-expiration}
+
+server:
+  port: ${shopping.server.port}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,32 +1,9 @@
 spring:
-  datasource:
-    url: jdbc:mysql://${db.host:localhost}:3306/${db.scheme:shopping}
-    username: ${db.username:root}
-    password: ${db.password:1234}
-    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: update
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
         jdbc:
           time_zone: Asia/Seoul
-        show_sql: true
-    show-sql: true
-  data:
-    redis:
-      ssl:
-        enabled: true
-      cluster:
-        nodes: ${redis.host:localhost:6379}
-        max-redirects: 3
-
-jwt:
-  secret: ${kt.jwt.secret:kt-cloud-tech-up-shopping-202511171107}
-  access-token-expiration: ${kt.jwt.access-token-expiration:300000}
-  refresh-token-expiration: ${kt.jwt.refresh-token-expiration:43200000}
-
-server:
-  port: 8080


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #112 

## 🔨변경 사항(Changes)
1. local, dev, prod 운영 환경 profile 반영 
  - local에서 개발 진행 시 intellij 프로젝트 설정 -> modify options -> environment variables에서 SPRING_PROFILES_ACTIVE=local 추가 해서 사용

2. redisconfiguration 운영 환경별  protocol, host 유연하게 적용
  - local은 ssl 미사용 및 cluster 미사용
  - dev는 유연하게 하기위해 cluster 설정 여부 및 ssl 사용여부 판단하여 protocol 및 host 설정
  - prod는 ssl 및 cluster 사용 전제
 
## 😉리뷰 요구사항
local, dev, prod 세 가지 환경을 예상하고 분리하였는데
저희 aws서버는 dev용으로 사용하는걸까요? prod용으로 사용하는걸까요?
