### PR TITLE
feat: api 요청 제한 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,8 @@ dependencies {
 	implementation 'com.slack.api:slack-api-client:1.43.1'
     implementation("io.netty:netty-resolver-dns-native-macos:4.1.117.Final:osx-aarch_64")
     implementation("io.netty:netty-resolver-dns:4.1.117.Final")
+
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 // fixed mockito error

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     implementation("io.netty:netty-resolver-dns:4.1.117.Final")
 
     implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+    implementation 'com.bucket4j:bucket4j-core:8.10.1'
+    implementation 'com.bucket4j:bucket4j-caffeine:8.10.1'
 }
 
 // fixed mockito error

--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -95,6 +95,10 @@ public enum ErrorCode {
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "해당 결제 정보를 찾을 수 없습니다"),
 	NOT_FOUND_PAYMENT_TYPE(HttpStatus.BAD_REQUEST, "결제수단을 찾을 수 없습니다"),
 
+	//rate limit
+	EXCEED_REQUEST_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "요청 횟수 제한을 초과했습니다. 잠시 후 다시 시도해주세요."),
+
+
 	//wishlist
 	ALREADY_WISHLISTED(HttpStatus.BAD_REQUEST, "이미 찜한 상품입니다.")
 	;

--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -96,8 +96,9 @@ public enum ErrorCode {
 	NOT_FOUND_PAYMENT_TYPE(HttpStatus.BAD_REQUEST, "결제수단을 찾을 수 없습니다"),
 
 	//rate limit
-	EXCEED_REQUEST_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "요청 횟수 제한을 초과했습니다. 잠시 후 다시 시도해주세요."),
-
+	GLOBAL_EXCEED_REQUEST_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "요청 횟수 제한을 초과했습니다."),
+	API_EXCEED_REQUEST_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "API 요청 횟수 제한을 초과했습니다."),
+	NO_HTTP_REQUEST(HttpStatus.BAD_REQUEST, "HTTP 요청 정보를 가져올 수 없습니다."),
 
 	//wishlist
 	ALREADY_WISHLISTED(HttpStatus.BAD_REQUEST, "이미 찜한 상품입니다.")

--- a/src/main/java/com/kt/common/ratelimit/annotation/KeyType.java
+++ b/src/main/java/com/kt/common/ratelimit/annotation/KeyType.java
@@ -1,0 +1,8 @@
+package com.kt.common.ratelimit.annotation;
+
+public enum KeyType {
+	IP,
+	USER_ID,
+	IP_AND_USER,
+	GLOBAL
+}

--- a/src/main/java/com/kt/common/ratelimit/annotation/RateLimit.java
+++ b/src/main/java/com/kt/common/ratelimit/annotation/RateLimit.java
@@ -1,0 +1,23 @@
+package com.kt.common.ratelimit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RateLimit {
+
+	// 용량
+	int capacity() default 10;
+
+	// 리필 토큰 갯수
+	int refillTokens() default 10;
+
+	// 리필 주기 현재는 초
+	int refillSeconds() default 60;
+
+	// 키타입(이 타입에 따라서 카페인에 저장됌)
+	KeyType keyType() default KeyType.USER_ID;
+}

--- a/src/main/java/com/kt/common/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/com/kt/common/ratelimit/aspect/RateLimitAspect.java
@@ -1,0 +1,91 @@
+package com.kt.common.ratelimit.aspect;
+
+import java.util.Objects;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.ratelimit.annotation.RateLimit;
+import com.kt.common.ratelimit.key.RateLimitKeyGenerator;
+import com.kt.common.ratelimit.manager.RateLimitManager;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitAspect {
+
+	private final RateLimitManager rateLimitManager;
+	private final RateLimitKeyGenerator keyGenerator;
+
+	@Around("@annotation(rateLimit)")
+	public Object handleRateLimit(ProceedingJoinPoint joinPoint, RateLimit rateLimit) throws Throwable {
+		HttpServletRequest request = getCurrentRequest();
+		String httpMethod = request.getMethod();
+		String path = request.getRequestURI();
+
+		// ratelimit:user_id(key_type):1(request):GET(method):_api_reviews_me(path)
+		String key = keyGenerator.generateKey(rateLimit.keyType(), request, httpMethod, path);
+
+		if (!rateLimitManager.tryConsume(key, rateLimit)) {
+			// 제한 초과 - 응답 헤더 추가 후 예외 발생
+			long secondsToWait = rateLimitManager.getSecondsToWait(key, rateLimit);
+			addHeaderExceeded(rateLimit, secondsToWait);
+
+			throw new CustomException(ErrorCode.API_EXCEED_REQUEST_LIMIT);
+		}
+
+		long availableTokens = rateLimitManager.getAvailableTokens(key, rateLimit);
+		addHeaderSuccess(rateLimit, availableTokens);
+
+		return joinPoint.proceed();
+	}
+
+	private HttpServletRequest getCurrentRequest() {
+		ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+		if (attributes == null) {
+			throw new CustomException(ErrorCode.NO_HTTP_REQUEST);
+		}
+
+		return attributes.getRequest();
+	}
+
+	private void addHeaderSuccess(RateLimit rateLimit, long availableTokens) {
+		HttpServletResponse response = ((ServletRequestAttributes)Objects.requireNonNull(
+			RequestContextHolder.getRequestAttributes())).getResponse();
+
+		if (response != null) {
+			response.setHeader("X-RateLimit-Limit", String.valueOf(rateLimit.capacity()));
+			response.setHeader("X-RateLimit-Remaining", String.valueOf(availableTokens));
+
+			long resetTime = System.currentTimeMillis() / 1000 + rateLimit.refillSeconds();
+			response.setHeader("X-RateLimit-Reset", String.valueOf(resetTime));
+		}
+	}
+
+	private void addHeaderExceeded(RateLimit rateLimit, long secondsToWait) {
+		HttpServletResponse response = ((ServletRequestAttributes)Objects.requireNonNull(
+			RequestContextHolder.getRequestAttributes())).getResponse();
+
+		if (response != null) {
+			response.setHeader("X-RateLimit-Limit", String.valueOf(rateLimit.capacity()));
+			response.setHeader("X-RateLimit-Remaining", "0");
+
+			long resetTime = System.currentTimeMillis() / 1000 + secondsToWait;
+			response.setHeader("X-RateLimit-Reset", String.valueOf(resetTime));
+			response.setHeader("Retry-After", String.valueOf(secondsToWait));
+		}
+	}
+}

--- a/src/main/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilter.java
+++ b/src/main/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilter.java
@@ -12,6 +12,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.kt.common.exception.ErrorCode;
 import com.kt.common.response.ErrorResponse;
+import com.kt.common.support.ClientIpResolver;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -44,7 +45,7 @@ public class GlobalRateLimitFilter extends OncePerRequestFilter {
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
 		FilterChain filterChain) throws ServletException, IOException {
 
-		String clientIp = getClientIp(request);
+		String clientIp = ClientIpResolver.getClientIp(request);
 
 		AtomicInteger counter = ipRequestCounter.get(clientIp, key -> new AtomicInteger(0));
 		int currentCount = counter.incrementAndGet();
@@ -70,39 +71,11 @@ public class GlobalRateLimitFilter extends OncePerRequestFilter {
 
 		String jsonResponse = String.format(
 			"{\"code\":\"%s\",\"message\":\"%s\"}",
-			ErrorCode.EXCEED_REQUEST_LIMIT.getStatus().toString(),
-			ErrorCode.EXCEED_REQUEST_LIMIT.getMessage() + String.format("[요청 횟수 제한을 초과했습니다. IP: %s, 현재 요청수: %d]", clientIp, currentCount)
+			ErrorCode.GLOBAL_EXCEED_REQUEST_LIMIT.getStatus().toString(),
+			ErrorCode.GLOBAL_EXCEED_REQUEST_LIMIT.getMessage() + String.format("[IP: %s, 현재 요청수: %d]", clientIp, currentCount)
 		);
 
 		response.getWriter().write(jsonResponse);
 		response.getWriter().flush();
-	}
-
-	private String getClientIp(HttpServletRequest request) {
-		String ip = request.getHeader("X-Forwarded-For");
-
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getHeader("Proxy-Client-IP");
-		}
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getHeader("WL-Proxy-Client-IP");
-		}
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getHeader("HTTP_CLIENT_IP");
-		}
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
-		}
-		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
-			ip = request.getRemoteAddr();
-		}
-
-		if (ip != null && ip.contains(",")) {
-			ip = ip.split(",")[0].trim();
-		}
-
-		log.debug("Extracted IP: {}", ip);
-
-		return ip;
 	}
 }

--- a/src/main/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilter.java
+++ b/src/main/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilter.java
@@ -1,0 +1,108 @@
+package com.kt.common.ratelimit.filter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.kt.common.exception.ErrorCode;
+import com.kt.common.response.ErrorResponse;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class GlobalRateLimitFilter extends OncePerRequestFilter {
+
+	private static final int MAX_REQUEST_SECONDS = 100;
+	private static final int EXPIRE_SECONDS = 1;
+	private static final int MAX_SIZE = 10000;
+
+	// AtomicInteger는 원자적으로 안전(쓰레드 세이프) -> 쓰레드별 카운트 잘못되는 문제 방지하기
+	private final Cache<String, AtomicInteger> ipRequestCounter;
+
+	public GlobalRateLimitFilter() {
+		this.ipRequestCounter = Caffeine.newBuilder()
+			.expireAfterWrite(EXPIRE_SECONDS, TimeUnit.SECONDS)
+			.maximumSize(MAX_SIZE)
+			.build();
+
+		log.info("===== GlobalRateLimitFilter 초기화 완료 =====");
+		log.info("Max requests per second: {}", MAX_REQUEST_SECONDS);
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String clientIp = getClientIp(request);
+
+		AtomicInteger counter = ipRequestCounter.get(clientIp, key -> new AtomicInteger(0));
+		int currentCount = counter.incrementAndGet();
+
+		log.debug("IP: {}, Count: {}/{}", clientIp, currentCount, MAX_REQUEST_SECONDS);
+
+		if (currentCount > MAX_REQUEST_SECONDS) {
+			log.warn("Rate limit exceeded for IP: {} (count: {})", clientIp, currentCount);
+			handleRateLimitExceeded(response, clientIp, currentCount);
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+
+	}
+
+	private void handleRateLimitExceeded(HttpServletResponse response, String clientIp, int currentCount)
+		throws IOException {
+
+		response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		String jsonResponse = String.format(
+			"{\"code\":\"%s\",\"message\":\"%s\"}",
+			ErrorCode.EXCEED_REQUEST_LIMIT.getStatus().toString(),
+			ErrorCode.EXCEED_REQUEST_LIMIT.getMessage() + String.format("[요청 횟수 제한을 초과했습니다. IP: %s, 현재 요청수: %d]", clientIp, currentCount)
+		);
+
+		response.getWriter().write(jsonResponse);
+		response.getWriter().flush();
+	}
+
+	private String getClientIp(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("Proxy-Client-IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("WL-Proxy-Client-IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("HTTP_CLIENT_IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getRemoteAddr();
+		}
+
+		if (ip != null && ip.contains(",")) {
+			ip = ip.split(",")[0].trim();
+		}
+
+		log.debug("Extracted IP: {}", ip);
+
+		return ip;
+	}
+}

--- a/src/main/java/com/kt/common/ratelimit/key/RateLimitKeyGenerator.java
+++ b/src/main/java/com/kt/common/ratelimit/key/RateLimitKeyGenerator.java
@@ -4,6 +4,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.common.ratelimit.annotation.KeyType;
 import com.kt.common.support.ClientIpResolver;
 import com.kt.security.CustomUserDetails;
@@ -39,10 +41,11 @@ public class RateLimitKeyGenerator {
 	private Long extractUserId() {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-		if (auth != null && auth.getPrincipal() instanceof CustomUserDetails userDetails) {
-			return userDetails.getId();
+		// USER_ID는 무조건 인증된 사용자만 접근해야한다
+		if (auth == null || !(auth.getPrincipal() instanceof CustomUserDetails userDetails)) {
+			throw new CustomException(ErrorCode.FORBIDDEN);
 		}
 
-		return 0L;
+		return userDetails.getId();
 	}
 }

--- a/src/main/java/com/kt/common/ratelimit/key/RateLimitKeyGenerator.java
+++ b/src/main/java/com/kt/common/ratelimit/key/RateLimitKeyGenerator.java
@@ -1,0 +1,48 @@
+package com.kt.common.ratelimit.key;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import com.kt.common.ratelimit.annotation.KeyType;
+import com.kt.common.support.ClientIpResolver;
+import com.kt.security.CustomUserDetails;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class RateLimitKeyGenerator {
+
+	public String generateKey(KeyType keyType, HttpServletRequest request, String httpMethod, String path) {
+		String identifier = extractIdentifier(keyType, request);
+
+		return String.format(
+			"rate_limit:%s:%s:%s:%s",
+			keyType.name().toLowerCase(),
+			identifier,
+			httpMethod,
+			path
+		);
+	}
+
+	private String extractIdentifier(KeyType keyType, HttpServletRequest request) {
+		return switch (keyType) {
+			case IP -> ClientIpResolver.getClientIp(request);
+			case USER_ID -> extractUserId().toString();
+			case IP_AND_USER -> ClientIpResolver.getClientIp(request) + ":" + extractUserId();
+			case GLOBAL -> "global";
+		};
+	}
+
+	private Long extractUserId() {
+		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+		if (auth != null && auth.getPrincipal() instanceof CustomUserDetails userDetails) {
+			return userDetails.getId();
+		}
+
+		return 0L;
+	}
+}

--- a/src/main/java/com/kt/common/ratelimit/manager/RateLimitManager.java
+++ b/src/main/java/com/kt/common/ratelimit/manager/RateLimitManager.java
@@ -1,0 +1,73 @@
+package com.kt.common.ratelimit.manager;
+
+import java.time.Duration;
+
+import org.springframework.stereotype.Component;
+
+import com.kt.common.ratelimit.annotation.RateLimit;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.BucketConfiguration;
+import io.github.bucket4j.ConsumptionProbe;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitManager {
+
+	private final ProxyManager<String> proxyManager;
+
+	// 토큰 검증 및 소비
+	public boolean tryConsume(String key, RateLimit rateLimit) {
+		BucketConfiguration configuration = buildConfiguration(rateLimit);
+
+		boolean success = proxyManager.builder()
+			.build(key, configuration)
+			.tryConsume(1);
+
+		if (!success) {
+			log.warn("Rate limit exceeded - key: {}, limit: {}, {} seconds", key, rateLimit.refillTokens(), rateLimit.refillSeconds());
+		}
+
+		return success;
+	}
+
+	// 남은 토큰 수 조회
+	public long getAvailableTokens(String key, RateLimit rateLimit) {
+		BucketConfiguration configuration = buildConfiguration(rateLimit);
+
+		return proxyManager.builder()
+			.build(key, configuration)
+			.getAvailableTokens();
+	}
+
+	//다음 대기시간
+	public long getSecondsToWait(String key, RateLimit rateLimit) {
+		BucketConfiguration configuration = buildConfiguration(rateLimit);
+
+		ConsumptionProbe probe = proxyManager.builder()
+			.build(key, configuration)
+			.tryConsumeAndReturnRemaining(1);
+
+		if (probe.isConsumed()) {
+			return 0;
+		}
+
+		return probe.getNanosToWaitForRefill() / 1_000_000_000;
+	}
+
+	// token bucket 설w정
+	private BucketConfiguration buildConfiguration(RateLimit rateLimit) {
+		Bandwidth limit = Bandwidth.builder()
+			.capacity(rateLimit.capacity())
+			.refillGreedy(rateLimit.refillTokens(), Duration.ofSeconds(rateLimit.refillSeconds()))
+			.build();
+
+		return BucketConfiguration.builder()
+			.addLimit(limit)
+			.build();
+	}
+}

--- a/src/main/java/com/kt/common/support/ClientIpResolver.java
+++ b/src/main/java/com/kt/common/support/ClientIpResolver.java
@@ -1,0 +1,32 @@
+package com.kt.common.support;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ClientIpResolver {
+
+	public static String getClientIp(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("Proxy-Client-IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("WL-Proxy-Client-IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("HTTP_CLIENT_IP");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+		}
+		if (ip == null || ip.isEmpty() || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getRemoteAddr();
+		}
+
+		if (ip != null && ip.contains(",")) {
+			ip = ip.split(",")[0].trim();
+		}
+
+		return ip != null ? ip : "unknown";
+	}
+}

--- a/src/main/java/com/kt/config/RateLimitConfiguration.java
+++ b/src/main/java/com/kt/config/RateLimitConfiguration.java
@@ -1,0 +1,30 @@
+package com.kt.config;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.github.bucket4j.caffeine.CaffeineProxyManager;
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class RateLimitConfiguration {
+
+	private static final int CACHE_MAX_SIZE = 100000;
+	private static final int CACHE_EXP_MINUTES = 60;
+
+
+	@Bean
+	public ProxyManager<String> bucketProxyManager() {
+		Caffeine<Object, Object> caffeineBuilder = Caffeine.newBuilder()
+			.maximumSize(CACHE_MAX_SIZE);
+
+		return new CaffeineProxyManager<>(caffeineBuilder, Duration.ofMinutes(CACHE_EXP_MINUTES));
+	}
+}

--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -1,6 +1,7 @@
 package com.kt.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kt.common.ratelimit.filter.GlobalRateLimitFilter;
 import com.kt.security.JwtAuthenticationFilter;
 import com.kt.security.JwtTokenProvider;
 import org.springframework.context.annotation.Bean;
@@ -32,8 +33,9 @@ public class SecurityConfiguration {
 	private static final String[] PUT_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] PATCH_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] DELETE_PERMIT_ALL = {"/api/v1/public/**"};
-    private final JwtTokenProvider jwtTokenProvider;
-    private final ObjectMapper objectMapper;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
+	private final GlobalRateLimitFilter globalRateLimitFilter;
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -68,7 +70,9 @@ public class SecurityConfiguration {
                 .logout(logout -> logout.disable())
                 .csrf(AbstractHttpConfigurer::disable);
 
-                http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,objectMapper), UsernamePasswordAuthenticationFilter.class);
+		http.addFilterBefore(globalRateLimitFilter, UsernamePasswordAuthenticationFilter.class);
+
+		http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,objectMapper), UsernamePasswordAuthenticationFilter.class);
 
 
 		return http.build();

--- a/src/main/java/com/kt/controller/review/ReviewController.java
+++ b/src/main/java/com/kt/controller/review/ReviewController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.kt.common.ratelimit.annotation.KeyType;
+import com.kt.common.ratelimit.annotation.RateLimit;
 import com.kt.common.response.ApiResult;
 import com.kt.common.request.Paging;
 import com.kt.common.support.SwaggerAssistance;
@@ -47,6 +49,12 @@ public class ReviewController extends SwaggerAssistance {
 		return ApiResult.ok(reviewService.create(currentUser.getId(), orderProductId, request));
 	}
 
+
+	@RateLimit(
+		capacity = 1,
+		refillTokens = 1,
+		keyType = KeyType.USER_ID
+	)
 	@GetMapping("/reviews/me")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "내 리뷰 목록 조회")

--- a/src/test/java/com/kt/common/ratelimit/GlobalRateLimitFilterTest.java
+++ b/src/test/java/com/kt/common/ratelimit/GlobalRateLimitFilterTest.java
@@ -1,0 +1,136 @@
+package com.kt.common.ratelimit;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import com.kt.common.ratelimit.filter.GlobalRateLimitFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class GlobalRateLimitFilterTest {
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private FilterChain filterChain;
+
+	private GlobalRateLimitFilter filter;
+	private final String TEST_IP = "192.168.0.100";
+
+	@BeforeEach
+	void setUp() throws Exception {
+		filter = new GlobalRateLimitFilter();
+	}
+
+	@Test
+	void 정상_요청은_통과() throws Exception {
+		// given
+		when(request.getRemoteAddr()).thenReturn(TEST_IP);
+
+		// when
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(filterChain, times(1)).doFilter(request, response);
+		verify(response, never()).setStatus(anyInt());
+	}
+
+	@Test
+	void 초당_100회_이하_요청은_모두_통과() throws Exception {
+		// given
+		when(request.getRemoteAddr()).thenReturn(TEST_IP);
+
+		// when - 100번 요청
+		for (int i = 0; i < 100; i++) {
+			filter.doFilter(request, response, filterChain);
+		}
+
+		// then
+		verify(filterChain, times(100)).doFilter(request, response);
+		verify(response, never()).setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+	}
+
+	@Test
+	void 초당_100회_초과_요청은_차단() throws Exception {
+		// given
+		when(request.getRemoteAddr()).thenReturn(TEST_IP);
+
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter writer = new PrintWriter(stringWriter);
+		when(response.getWriter()).thenReturn(writer);
+
+		// when - 100번은 통과
+		for (int i = 0; i < 100; i++) {
+			filter.doFilter(request, response, filterChain);
+		}
+
+		// when - 101번째 요청
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(filterChain, times(100)).doFilter(request, response);
+		verify(response, times(1)).setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+
+		String responseBody = stringWriter.toString();
+		assertThat(responseBody).contains("429 TOO_MANY_REQUESTS");
+		assertThat(responseBody).contains("192.168.0.100");
+	}
+
+	@Test
+	void 서로_다른_IP는_독립적으로_카운트() throws Exception {
+		// given
+		String test_ip_1 = "192.168.0.100";
+		String test_ip_2 = "192.168.0.101";
+
+		// when
+		when(request.getRemoteAddr()).thenReturn(test_ip_1);
+		for (int i = 0; i < 100; i++) {
+			filter.doFilter(request, response, filterChain);
+		}
+
+		// when
+		when(request.getRemoteAddr()).thenReturn(test_ip_2);
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(filterChain, times(101)).doFilter(request, response);
+		verify(response, never()).setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+	}
+
+	@Test
+	void 카운터_리셋() throws Exception {
+		// given
+		when(request.getRemoteAddr()).thenReturn(TEST_IP);
+
+		// when
+		for (int i = 0; i < 100; i++) {
+			filter.doFilter(request, response, filterChain);
+		}
+
+		Thread.sleep(1100);
+
+		// when - 리셋되어 통과해야 함
+		filter.doFilter(request, response, filterChain);
+
+		// then
+		verify(filterChain, times(101)).doFilter(request, response);
+		verify(response, never()).setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+	}
+}

--- a/src/test/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilterTest.java
+++ b/src/test/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilterTest.java
@@ -1,4 +1,4 @@
-package com.kt.common.ratelimit;
+package com.kt.common.ratelimit.filter;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.*;
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-
-import com.kt.common.ratelimit.filter.GlobalRateLimitFilter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/test/java/com/kt/common/ratelimit/manager/RateLimitManagerTest.java
+++ b/src/test/java/com/kt/common/ratelimit/manager/RateLimitManagerTest.java
@@ -1,0 +1,160 @@
+package com.kt.common.ratelimit.manager;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kt.common.ratelimit.annotation.KeyType;
+import com.kt.common.ratelimit.annotation.RateLimit;
+
+import io.github.bucket4j.distributed.proxy.ProxyManager;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+public class RateLimitManagerTest {
+
+	@Autowired
+	private RateLimitManager rateLimitManager;
+
+	@Autowired
+	private ProxyManager<String> proxyManager;
+
+	// 테스트에서 사용한 키들을 추적
+	private final Set<String> usedKeys = new HashSet<>();
+
+	private final static String DEFAULT_KEY = "test:user:1:POST:/api/reviews";
+
+	@AfterEach
+	void tearDown() {
+		usedKeys.forEach(proxyManager::removeProxy);
+		usedKeys.clear();
+	}
+
+	private String trackKey(String key) {
+		usedKeys.add(key);
+		return key;
+	}
+
+	private RateLimit createRateLimit(int capacity, int refillTokens, int refillSeconds) {
+		return new RateLimit() {
+			@Override
+			public Class<? extends Annotation> annotationType() {
+				return RateLimit.class;
+			}
+
+			@Override
+			public int capacity() {
+				return capacity;
+			}
+
+			@Override
+			public int refillTokens() {
+				return refillTokens;
+			}
+
+			@Override
+			public int refillSeconds() {
+				return refillSeconds;
+			}
+
+			@Override
+			public KeyType keyType() {
+				return KeyType.USER_ID;
+			}
+		};
+	}
+
+	@Test
+	void 토큰_소비_성공() {
+		// given
+		RateLimit rateLimit = createRateLimit(5, 5, 60);
+
+		//when
+		boolean result = rateLimitManager.tryConsume(trackKey(DEFAULT_KEY), rateLimit);
+
+		//then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void 토큰_소진_후_소비_실패() {
+
+		// given
+		String key = trackKey(DEFAULT_KEY);
+
+		RateLimit rateLimit = createRateLimit(3, 3, 60);
+
+		// when
+		for (int i = 0; i < 3; i++) {
+			boolean result = rateLimitManager.tryConsume(key, rateLimit);
+			assertThat(result).isTrue();
+		}
+
+		// then
+		boolean result = rateLimitManager.tryConsume(key, rateLimit);
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	void 남은_토큰_수_조회() {
+
+		// given
+		String key = trackKey(DEFAULT_KEY);
+
+		RateLimit rateLimit = createRateLimit(5, 5, 60);
+
+		// when
+		rateLimitManager.tryConsume(key, rateLimit);
+		rateLimitManager.tryConsume(key, rateLimit);
+
+		// then
+		long availableTokens = rateLimitManager.getAvailableTokens(key, rateLimit);
+		assertThat(availableTokens).isEqualTo(3);
+	}
+
+	@Test
+	void 서로_다른_키로_토큰_소비() {
+
+		// given
+		String key = trackKey(DEFAULT_KEY);
+
+		String otherKey = "test:user:7:POST:/api/reviews"; // 7번
+		RateLimit rateLimit = createRateLimit(3, 3, 60);
+
+		//when
+		for (int i = 0; i < 3; i++) {
+			rateLimitManager.tryConsume(key, rateLimit);
+		}
+
+		boolean result = rateLimitManager.tryConsume(otherKey, rateLimit);
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	void 토큰_소진_시_대기_시간_조회() {
+		// given
+		String key = trackKey(DEFAULT_KEY);
+
+		RateLimit rateLimit = createRateLimit(2, 2, 60);
+
+		// when
+		for (int i = 0; i < 2; i++) {
+			rateLimitManager.tryConsume(key, rateLimit);
+		}
+
+		// then
+		long waitTime = rateLimitManager.getSecondsToWait(key, rateLimit);
+		assertThat(waitTime).isGreaterThan(0);
+		assertThat(waitTime).isLessThanOrEqualTo(60);
+	}
+}


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #156 

## 🔨변경 사항(Changes)
1. filter IP 기반 요청 제한 추가(초당 100회 / 초당 횟수 초기화 / IP 갯수 1만개 저장 후 비교(카페인 기반 캐시))
2. 테스트 코드 추가
3. aop+bucekt 요청 제한 추가

controller - aop+bucket4j 설명

rateLimit

1. capacity - 용량
2. refilltokens - 리필 토큰 갯수
3. refillSeconds - 리필 주기
4. keyType -  저장키(redis 사용하지 않고 caffeine에 저장-서버 메모리)

@RateLimit(
    capacity = 10, - 최대 요청 가능 횟수(용량)
    refillTokens = 1, - refillSeconds마다 충전되는 토큰 갯수
    refillSeconds = 60, - 충전 시간
    keyType = KeyType.IP - 저장 keyType

)

ex) 상품 조회(비인증) - 비인증, 인증 모두 가능해야하므로 IP 식별

@GetMapping("/products")
@RateLimit(
    capacity = 200,
    refillTokens = 200,
    refillSeconds = 60,
    keyType = KeyType.IP

)
public ApiResult<Page<UserProductListResponse>> getProductList

ex) 내 정보 조회(인증) - 인증된 사용자가 가능해야하므로 USER_ID 식별

@GetMapping("/users/me")
@RateLimit(
    capacity = 100,
    refillTokens = 100,
    refillSeconds = 60,
    keyType = KeyType.USER_ID

)
public ApiResult<UserInfoResponse> getMyInfo()

## 😉리뷰 요구사항
아래 노션에 기술 선택 이유와 사용법 등 작성해놨습니다(메모장 처럼 활용해서 정리는 부족합니다..)
https://www.notion.so/API-2d39e3e335cc8058a903de27ff5b4878

추가적으로 테스트나 시연용으로 해당 기술이 적용된 도메인을 하나 선정해서 사용 또는 각자 도메인에서 사용하고 싶은대로 사용 결정하면 될 것 같습니다! 저는 시간상 전자 추천드립니다.