### PR TITLE
refactor: order 배송지, 결제 리팩토링 / cart, wishlist 생성 이벤트 발행 및 eventPublisher 추가

### DIFF
--- a/src/main/java/com/kt/dto/order/OrderCreateRequest.java
+++ b/src/main/java/com/kt/dto/order/OrderCreateRequest.java
@@ -18,7 +18,7 @@ public record OrderCreateRequest(
 	String receiverPhone,
 
 	@Schema(description = "주문자 배송지 아이디", example = "1")
-	@NotNull(message = "배송지 정보 입력은 필수입니다")
+	// @NotNull(message = "배송지 정보 입력은 필수입니다")
 	Long receiverAddressId,
 
 	@ArraySchema(

--- a/src/main/java/com/kt/event/CartItemAddedEvent.java
+++ b/src/main/java/com/kt/event/CartItemAddedEvent.java
@@ -1,0 +1,4 @@
+package com.kt.event;
+
+public record CartItemAddedEvent() {
+}

--- a/src/main/java/com/kt/event/CartItemAddedEvent.java
+++ b/src/main/java/com/kt/event/CartItemAddedEvent.java
@@ -1,4 +1,7 @@
 package com.kt.event;
 
-public record CartItemAddedEvent() {
+public record CartItemAddedEvent(
+	Long userId,
+	Long productId
+) {
 }

--- a/src/main/java/com/kt/event/WishlistAddedEvent.java
+++ b/src/main/java/com/kt/event/WishlistAddedEvent.java
@@ -1,0 +1,7 @@
+package com.kt.event;
+
+public record WishlistAddedEvent(
+	Long userId,
+	Long productId
+) {
+}

--- a/src/main/java/com/kt/service/cart/CartService.java
+++ b/src/main/java/com/kt/service/cart/CartService.java
@@ -15,6 +15,7 @@ import com.kt.domain.product.Product;
 import com.kt.dto.cart.CartCreateRequest;
 import com.kt.dto.cart.response.CartResponse;
 import com.kt.dto.discount.response.DiscountResult;
+import com.kt.event.CartItemAddedEvent;
 import com.kt.repository.cart.CartRepository;
 import com.kt.repository.discountmembership.DiscountMembershipRepository;
 import com.kt.repository.discountproduct.DiscountProductRepository;
@@ -23,11 +24,12 @@ import com.kt.repository.user.UserRepository;
 import com.kt.repository.variant.VariantRepository;
 import com.kt.service.discount.DiscountCalcService;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -38,6 +40,7 @@ public class CartService {
 	private final ProductRepository productRepository;
 	private final VariantRepository variantRepository;
 	private final DiscountCalcService discountCalcService;
+	private final ApplicationEventPublisher eventPublisher;
 
     public Long create(Long userId, CartCreateRequest request) {
 		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
@@ -59,6 +62,10 @@ public class CartService {
 			product
 		);
 		cartRepository.save(newCart);
+
+		eventPublisher.publishEvent(
+			new CartItemAddedEvent(userId, product.getId())
+		);
 
 		return newCart.getId();
     }

--- a/src/main/java/com/kt/service/order/OrderService.java
+++ b/src/main/java/com/kt/service/order/OrderService.java
@@ -25,6 +25,7 @@ import com.kt.domain.order.Order;
 import com.kt.domain.order.OrderStatus;
 import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.product.ProductStatus;
+import com.kt.domain.shoppingaddress.ShoppingAddress;
 import com.kt.domain.user.User;
 import com.kt.dto.discount.response.DiscountResult;
 import com.kt.dto.order.OrderCreateRequest;
@@ -62,7 +63,18 @@ public class OrderService {
 
 	public Long create(Long userId, OrderCreateRequest request) {
 		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
-		var address = shoppingAddressRepository.findByIdOrThrow(request.receiverAddressId(), ErrorCode.NOT_FOUND_SHOPPING_ADDRESS);
+		ShoppingAddress address;
+
+		if (request.receiverAddressId() != null) {
+			address = shoppingAddressRepository.findByIdOrThrow(request.receiverAddressId(),
+				ErrorCode.NOT_FOUND_SHOPPING_ADDRESS);
+
+			// 사용자 본인이 등록한 배송지인지 검증
+			Preconditions.validate(address.getUser().getId().equals(userId), ErrorCode.NOT_FOUND_SHOPPING_ADDRESS);
+		} else {
+			address = shoppingAddressRepository.findFirstByUserIdAndIsDefaultTrueOrderByIdDesc(userId)
+				.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_SHOPPING_ADDRESS));
+		}
 
 		// 1. 주문 생성
 		var newOrder = new Order(
@@ -76,13 +88,16 @@ public class OrderService {
 
 		// 2. 전체 product 검증
 		request.products().forEach(product -> {
-			var targetProduct = productRepository.findByIdOrThrow(product.productId(),  ErrorCode.NOT_FOUND_PRODUCT);
+			var targetProduct = productRepository.findByIdOrThrow(product.productId(), ErrorCode.NOT_FOUND_PRODUCT);
 
-			Preconditions.validate(targetProduct.getStatus().equals(ProductStatus.ACTIVATED), ErrorCode.CANNOT_PURCHASE_PRODUCT);
+			Preconditions.validate(targetProduct.getStatus().equals(ProductStatus.ACTIVATED),
+				ErrorCode.CANNOT_PURCHASE_PRODUCT);
 			Preconditions.validate(targetProduct.getStock() >= product.productCount(), ErrorCode.NOT_ENOUGH_STOCK);
 			//선택한 상품의 옵션이 맞는지 검증
-			var variant = variantRepository.findByIdAndDeletedFalseOrThrow(product.productVariantId(), ErrorCode.NOT_FOUND_VARIANT);
-			Preconditions.validate(variant.getProduct().getId().equals(targetProduct.getId()), ErrorCode.INVALID_VARIANT);
+			var variant = variantRepository.findByIdAndDeletedFalseOrThrow(product.productVariantId(),
+				ErrorCode.NOT_FOUND_VARIANT);
+			Preconditions.validate(variant.getProduct().getId().equals(targetProduct.getId()),
+				ErrorCode.INVALID_VARIANT);
 
 			// OrderProduct 생성
 			var newOrderProduct = new OrderProduct(

--- a/src/main/java/com/kt/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/service/payment/PaymentService.java
@@ -77,7 +77,7 @@ public class PaymentService {
 
 		paymentRepository.save(payment);
 
-		order.updateStatus(OrderStatus.SHIPPED);
+		order.updateStatus(OrderStatus.PAID);
 	}
 
 	public Page<PaymentListResponse> getMyAllPayment(Long userId, Pageable pageable) {

--- a/src/main/java/com/kt/service/wishlist/WishlistService.java
+++ b/src/main/java/com/kt/service/wishlist/WishlistService.java
@@ -8,7 +8,6 @@ import com.kt.common.exception.ErrorCode;
 import com.kt.domain.product.Product;
 import com.kt.domain.user.User;
 import com.kt.domain.wishlist.Wishlist;
-import com.kt.event.CartItemAddedEvent;
 import com.kt.event.WishlistAddedEvent;
 import com.kt.repository.WishlistRepository;
 import com.kt.repository.product.ProductRepository;

--- a/src/main/java/com/kt/service/wishlist/WishlistService.java
+++ b/src/main/java/com/kt/service/wishlist/WishlistService.java
@@ -1,25 +1,31 @@
 package com.kt.service.wishlist;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kt.common.exception.CustomException;
 import com.kt.common.exception.ErrorCode;
 import com.kt.domain.product.Product;
 import com.kt.domain.user.User;
 import com.kt.domain.wishlist.Wishlist;
+import com.kt.event.CartItemAddedEvent;
+import com.kt.event.WishlistAddedEvent;
 import com.kt.repository.WishlistRepository;
 import com.kt.repository.product.ProductRepository;
 import com.kt.repository.user.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class WishlistService {
 
 	private final WishlistRepository wishlistRepository;
 	private final UserRepository userRepository;
 	private final ProductRepository productRepository;
+	private final ApplicationEventPublisher eventPublisher;
 
 	public void addWishlist(Long userId, Long productId) {
 		User user = userRepository.findById(userId)
@@ -34,5 +40,9 @@ public class WishlistService {
 
 		Wishlist wishlist = new Wishlist(user, product);
 		wishlistRepository.save(wishlist);
+
+		eventPublisher.publishEvent(
+			new WishlistAddedEvent(userId, productId)
+		);
 	}
 }

--- a/src/test/java/com/kt/service/payment/PaymentServiceTest.java
+++ b/src/test/java/com/kt/service/payment/PaymentServiceTest.java
@@ -118,7 +118,7 @@ class PaymentServiceTest {
 		assertThat(payment.getFinalPrice()).isEqualTo(23000);
 
 		Order updatedOrder = orderRepository.findById(order.getId()).get();
-		assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.SHIPPED);
+		assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.PAID);
 	}
 
 	@Test


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호

## 🔨변경 사항(Changes)
-Order 주문 생성 시 배송지 미입력일 경우 기존에 유저가 default 로 저장해둔 배송지 주소들 중 가장 최근에 주문 할 때 사용했던 배송지 주소를 해당 주문의 default 주소로 설정하는 로직 추가
-Order 주문 생성 시 유저 본인의 배송지인지 검증하는 로직 추가
-배송지 미입력일 경우 default 설정을 위해 orderCreateRequest 에서 @Notnull Long addressId 를 주석 처리
-Payment 생성 시 주문 상태값 PAID 로 변경 / PaymentServiceTest 의 기대값 PAID 로 변경
-cart, wishlist 생성 이벤트 발행 (CartItemAddedEvent, WishlistAddedEvent)
-cart, wishlist 사용자 정보를 얻기 위해 각 도메인의 service - create / addWishlist 에 생성 이벤트 발행하는 로직 추가 (eventPublisher)
-wishlist 에 @Transactional (springframework) 추가

## 😉리뷰 요구사항
-이전에 두 브랜치에서 작업하던 내용이 있어서 부득이하게 하나의 브랜치에 통합했습니다.. 양해 부탁드립니다

