### PR TITLE
feat: toss 결제 모듈 연동 개발

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -94,6 +94,10 @@ public enum ErrorCode {
 	//payment
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "해당 결제 정보를 찾을 수 없습니다"),
 	NOT_FOUND_PAYMENT_TYPE(HttpStatus.BAD_REQUEST, "결제수단을 찾을 수 없습니다"),
+	FAIL_PAYMENT(HttpStatus.BAD_REQUEST, "결제에 실패했습니다."),
+	ALREADY_PAID_ORDER(HttpStatus.BAD_REQUEST, "이미 결제가 완료된 주문입니다."),
+	CANNOT_CANCEL_PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 취소 금액이 결제 금액과 일치하지 않습니다."),
+	PAYMENT_CANCEL_FAILED(HttpStatus.BAD_REQUEST, "결제 취소에 실패했습니다."),
 
 	//rate limit
 	GLOBAL_EXCEED_REQUEST_LIMIT(HttpStatus.TOO_MANY_REQUESTS, "요청 횟수 제한을 초과했습니다."),

--- a/src/main/java/com/kt/config/RestTemplateConfiguration.java
+++ b/src/main/java/com/kt/config/RestTemplateConfiguration.java
@@ -1,0 +1,15 @@
+package com.kt.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+
+}

--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -28,8 +28,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfiguration {
 
 
-	private static final String[] GET_PERMIT_ALL = {"/api/health/**", "/swagger-ui.html","/swagger-ui/**", "/v3/api-docs/**", "/actuator/**"};
-	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login","/api/admin/users/auth/signup", "/api/admin/users/auth/login","/api/users/reissue"};
+	private static final String[] GET_PERMIT_ALL = {"/api/health/**", "/swagger-ui.html","/swagger-ui/**", "/v3/api-docs/**", "/actuator/**", "/payment-*.html", "/api/payments/client-key", "/*.css"};
+	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login","/api/admin/users/auth/signup", "/api/admin/users/auth/login","/api/users/reissue", "/api/payments/confirm"};
 	private static final String[] PUT_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] PATCH_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] DELETE_PERMIT_ALL = {"/api/v1/public/**"};

--- a/src/main/java/com/kt/controller/payment/PaymentController.java
+++ b/src/main/java/com/kt/controller/payment/PaymentController.java
@@ -1,7 +1,15 @@
 package com.kt.controller.payment;
 
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,14 +18,26 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
 
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
 import com.kt.common.request.Paging;
 import com.kt.common.response.ApiResult;
 import com.kt.common.support.SwaggerAssistance;
+import com.kt.domain.order.Order;
+import com.kt.domain.order.OrderStatus;
 import com.kt.dto.payment.PaymentCreateRequest;
 import com.kt.dto.payment.PaymentDetailResponse;
 import com.kt.dto.payment.PaymentListResponse;
+import com.kt.dto.payment.PaymentOrderInfoResponse;
+import com.kt.dto.payment.PaymentTossCancelRequest;
+import com.kt.dto.payment.PaymentTossCancelResponse;
+import com.kt.dto.payment.PaymentTossConfirmRequest;
+import com.kt.properties.TossPaymentsProperties;
 import com.kt.security.CustomUserDetails;
+import com.kt.service.order.OrderService;
 import com.kt.service.payment.PaymentService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,6 +52,9 @@ import lombok.RequiredArgsConstructor;
 public class PaymentController extends SwaggerAssistance {
 
 	private final PaymentService paymentService;
+	private final OrderService orderService;
+	private final TossPaymentsProperties tossPaymentsProperties;
+	private final RestTemplate restTemplate = new RestTemplate();
 
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
@@ -53,11 +76,147 @@ public class PaymentController extends SwaggerAssistance {
 		return ApiResult.ok(paymentService.getPayment(currentUser.getId(), paymentId));
 	}
 
-	@PostMapping("")
+	/*결제기록 등록 -> toss 결제 이후 성공 시 등록 변경*/
+	/*@PostMapping("")
 	@Operation(summary = "결제 기록 등록")
 	public ApiResult<Void> create(@Valid @RequestBody PaymentCreateRequest request, @AuthenticationPrincipal CustomUserDetails currentUser) {
 		paymentService.create(request, currentUser.getId());
 		return ApiResult.ok();
+	}*/
+
+	@PostMapping("/confirm")
+	@Operation(summary = "Toss 결제 승인 요청")
+	public ResponseEntity<?> confirmPayment(@RequestBody PaymentTossConfirmRequest request,
+		@AuthenticationPrincipal CustomUserDetails currentUser
+	) {
+		try {
+			String url = tossPaymentsProperties.getApiUrl() + "/confirm";
+			String auth = tossPaymentsProperties.getSecretKey() + ":";
+			String encodedAuth = java.util.Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+
+			String orderId = request.orderId().split("-")[0];
+			Long orderIdLong = Long.parseLong(orderId);
+			var order = orderService.getOrderDetail(orderIdLong, currentUser.getId());
+			if (order.orderStatus() != OrderStatus.ORDERED) {
+				return ResponseEntity
+					.status(HttpStatus.BAD_REQUEST)
+					.body(Map.of(
+						"code", ErrorCode.ALREADY_PAID_ORDER.getStatus(),
+						"message", ErrorCode.ALREADY_PAID_ORDER.getMessage()
+					));
+			}
+
+			HttpHeaders headers = new HttpHeaders();
+			headers.add("Authorization", "Basic " + encodedAuth);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+			System.out.println(request.toString());
+			Map<String, String> body = Map.of(
+				"paymentKey", request.paymentKey(),
+				"orderId", request.orderId(),
+				"amount", request.amount().toString()
+			);
+
+			HttpEntity<Map<String, String>> entity = new HttpEntity<>(body, headers);
+			ResponseEntity<Map> response = restTemplate.postForEntity(url, entity, Map.class);
+
+			if (response.getStatusCode() == HttpStatus.OK) {
+				Map<String, Object> tossPayment = response.getBody();
+				Long paymentId = paymentService.create(tossPayment, currentUser.getId());
+
+				Map<String, Object> responseBody = new HashMap<>(tossPayment);
+				responseBody.put("paymentId", paymentId);
+
+				return ResponseEntity.ok(responseBody);
+			}
+
+			return ResponseEntity.ok(response.getBody());
+
+		} catch (HttpClientErrorException e) {
+			// Toss API에서 반환한 에러 응답을 그대로 전달
+			return ResponseEntity
+				.status(e.getStatusCode())
+				.body(e.getResponseBodyAsString());
+		} catch (Exception e) {
+			e.printStackTrace();
+			return ResponseEntity
+				.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(Map.of(
+					"code", "INTERNAL_SERVER_ERROR",
+					"message", "결제 승인 처리 중 오류가 발생했습니다: " + e.getMessage()
+				));
+		}
+	}
+
+	@GetMapping("/order/{orderId}")
+	@Operation(summary = "주문 ID로 결제 정보 조회")
+	public ApiResult<PaymentDetailResponse> getPaymentByOrderId(
+		@PathVariable Long orderId,
+		@AuthenticationPrincipal CustomUserDetails currentUser
+	) {
+		return ApiResult.ok(paymentService.getPaymentByOrderId(currentUser.getId(), orderId));
+	}
+
+	@PostMapping("/{paymentId}/cancel")
+	@Operation(summary = "결제 취소")
+	public ResponseEntity<?> cancelPayment(
+		@PathVariable Long paymentId,
+		@RequestBody PaymentTossCancelRequest request,
+		@AuthenticationPrincipal CustomUserDetails currentUser) {
+		try {
+			String paymentKey = paymentService.getPaymentKey(paymentId, currentUser.getId());
+
+
+			String url = tossPaymentsProperties.getApiUrl() + "/" + paymentKey + "/cancel";
+			String auth = tossPaymentsProperties.getSecretKey() + ":";
+			String encodedAuth = java.util.Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8));
+
+			HttpHeaders headers = new HttpHeaders();
+			headers.add("Authorization", "Basic " + encodedAuth);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+
+			Map<String, Object> body = new HashMap<>();
+			body.put("cancelReason", request.cancelReason());
+			if (request.cancelAmount() != null) {
+				body.put("cancelAmount", request.cancelAmount());
+			}
+
+			HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+			ResponseEntity<Map> tossResponse = restTemplate.postForEntity(url, entity, Map.class);
+
+			if (tossResponse.getStatusCode() == HttpStatus.OK) {
+				PaymentTossCancelResponse response = paymentService.cancelPayment(request, currentUser.getId(), paymentId);
+				return ResponseEntity.ok(ApiResult.ok(response));
+			}
+
+			throw new CustomException(ErrorCode.PAYMENT_CANCEL_FAILED);
+
+		} catch (HttpClientErrorException e) {
+			// Toss API에서 반환한 에러 응답을 그대로 전달
+			return ResponseEntity
+				.status(e.getStatusCode())
+				.body(e.getResponseBodyAsString());
+		} catch (Exception e) {
+			e.printStackTrace();
+			return ResponseEntity
+				.status(HttpStatus.INTERNAL_SERVER_ERROR)
+				.body(Map.of(
+					"code", "INTERNAL_SERVER_ERROR",
+					"message", "결제 승인 처리 중 오류가 발생했습니다: " + e.getMessage()
+				));
+		}
+	}
+
+	@GetMapping("/order/{orderId}/info")
+	@Operation(summary = "주문 번호로 결제 정보 조회")
+	public ApiResult<PaymentOrderInfoResponse> getPaymentDetail(@PathVariable Long orderId,
+		@AuthenticationPrincipal CustomUserDetails currentUser) {
+		return ApiResult.ok(paymentService.getPaymentDetail(currentUser.getId(), orderId));
+	}
+
+	@GetMapping("/client-key")
+	@Operation(summary = "Toss 클라이언트 키 조회")
+	public ApiResult<Map<String, String>> getClientKey() {
+		return ApiResult.ok(Map.of("clientKey", tossPaymentsProperties.getClientKey()));
 	}
 
 

--- a/src/main/java/com/kt/domain/payment/Payment.java
+++ b/src/main/java/com/kt/domain/payment/Payment.java
@@ -29,6 +29,9 @@ public class Payment extends BaseEntity {
 	private Long finalPrice;    // 총 결제 금액 (상품금액 + 배송비)
 
 	@Column(nullable = false)
+	private String paymentKey;
+
+	@Column(nullable = false)
 	private boolean isDeleted = false;
 
 	@OneToOne(fetch = FetchType.LAZY)
@@ -44,13 +47,15 @@ public class Payment extends BaseEntity {
 		PaymentType paymentType,
 		Long totalPrice,
 		Long deliveryFee,
-		Long finalPrice
+		Long finalPrice,
+		String paymentKey
 	) {
 		this.order = order;
 		this.paymentType = paymentType;
 		this.totalPrice = totalPrice;
 		this.deliveryFee = deliveryFee;
 		this.finalPrice = finalPrice;
+		this.paymentKey = paymentKey;
 		this.isDeleted = false;
 	}
 

--- a/src/main/java/com/kt/dto/discount/response/DiscountInfo.java
+++ b/src/main/java/com/kt/dto/discount/response/DiscountInfo.java
@@ -1,0 +1,8 @@
+package com.kt.dto.discount.response;
+
+public record DiscountInfo(
+	String discountName,
+	String discountType,
+	Long discountPrice
+) {
+}

--- a/src/main/java/com/kt/dto/payment/PaymentDetailResponse.java
+++ b/src/main/java/com/kt/dto/payment/PaymentDetailResponse.java
@@ -7,6 +7,7 @@ import com.kt.domain.order.OrderStatus;
 public record PaymentDetailResponse(
 	Long id, // 결제 ID
 	Long orderId, // 주문 ID
+	String paymentKey, // 결제 고유 키
 	String userLoginId, // 결제자 아이디(직접 결제한 유저는 로그인한 유저)
 	String userName, // 결제자 이름
 	OrderStatus orderStatus, // 주문 상태

--- a/src/main/java/com/kt/dto/payment/PaymentOrderInfoResponse.java
+++ b/src/main/java/com/kt/dto/payment/PaymentOrderInfoResponse.java
@@ -1,0 +1,57 @@
+package com.kt.dto.payment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.kt.domain.order.OrderStatus;
+import com.kt.dto.order.response.OrderProductResponse;
+
+public record PaymentOrderInfoResponse(
+	Long orderId,
+	OrderStatus orderStatus,
+	String orderStatusDescription,
+	LocalDateTime createdAt,
+	String receiverName,
+	String receiverPhone,
+	String receiverAddress,
+	UserPaymentInfo user,
+	List<OrderProductInfo> orderProducts,
+	PriceInfo priceInfo
+) {
+	public record UserPaymentInfo(
+		String name,
+		String email,
+		String mobile,
+		MembershipInfo membership,
+		Long money
+	) {}
+
+	public record MembershipInfo(
+		String level
+	) {}
+
+	public record AppliedDiscountInfo(
+		String discountName,
+		String discountType,
+		Long discountAmount
+	) {}
+
+	public record PriceInfo(
+		Long totalProductPrice,
+		Long totalDiscountPrice,
+		Long deliveryFee,
+		Long finalPrice
+	) {}
+
+	public record OrderProductInfo(
+		Long productId,
+		String productName,
+		Long productVariantId,
+		Long productCount,
+		Long price,
+		Long totalPrice,
+		Long discountPrice,
+		Long discountedPrice,
+		List<AppliedDiscountInfo> appliedDiscounts  // 할인 목록 포함
+	) {}
+}

--- a/src/main/java/com/kt/dto/payment/PaymentTossCancelRequest.java
+++ b/src/main/java/com/kt/dto/payment/PaymentTossCancelRequest.java
@@ -1,0 +1,16 @@
+package com.kt.dto.payment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentTossCancelRequest(
+	@Schema(description = "취소 사유", example = "고객 변심")
+	@NotBlank(message = "취소 사유는 필수입니다")
+	String cancelReason,
+
+	@Schema(description = "취소 금액", example = "50000")
+	@NotNull(message = "취소 금액은 필수입니다")
+	Long cancelAmount
+) {
+}

--- a/src/main/java/com/kt/dto/payment/PaymentTossCancelResponse.java
+++ b/src/main/java/com/kt/dto/payment/PaymentTossCancelResponse.java
@@ -1,0 +1,8 @@
+package com.kt.dto.payment;
+
+public record PaymentTossCancelResponse(
+		Long cancelAmount,
+		String cancelReason,
+		String canceledAt
+) {
+}

--- a/src/main/java/com/kt/dto/payment/PaymentTossConfirmRequest.java
+++ b/src/main/java/com/kt/dto/payment/PaymentTossConfirmRequest.java
@@ -1,0 +1,26 @@
+package com.kt.dto.payment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PaymentTossConfirmRequest(
+
+	@Schema(description = "주문 ID", example = "1")
+	@NotNull(message = "주문 ID는 필수입니다")
+	String orderId,
+
+	@Schema(description = "결제 KEY", example = "tgen_20260104212559xFAo0")
+	@NotBlank(message = "결제 KEY는 필수입니다")
+	String paymentKey,
+
+	@Schema(description = "결제 금액", example = "50000")
+	@NotNull(message = "결제 금액은 필수입니다")
+	Long amount,
+
+	@Schema(description = "결제타입", example = "간편결제")
+	@NotBlank(message = "결제타입은 필수입니다")
+	String method
+
+) {
+}

--- a/src/main/java/com/kt/properties/TossPaymentsProperties.java
+++ b/src/main/java/com/kt/properties/TossPaymentsProperties.java
@@ -1,0 +1,25 @@
+package com.kt.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties(prefix = "toss.payments")
+public class TossPaymentsProperties {
+		private String clientKey;
+		private String secretKey;
+		private String apiUrl;
+
+		@PostConstruct
+		public void init() {
+			System.out.println("TossPaymentsProperties initialized with clientKey: " + clientKey);
+			System.out.println("apiUrl: " + apiUrl);
+			System.out.println("secretKey: " + secretKey);
+		}
+}

--- a/src/main/java/com/kt/properties/TossPaymentsProperties.java
+++ b/src/main/java/com/kt/properties/TossPaymentsProperties.java
@@ -15,11 +15,4 @@ public class TossPaymentsProperties {
 		private String clientKey;
 		private String secretKey;
 		private String apiUrl;
-
-		@PostConstruct
-		public void init() {
-			System.out.println("TossPaymentsProperties initialized with clientKey: " + clientKey);
-			System.out.println("apiUrl: " + apiUrl);
-			System.out.println("secretKey: " + secretKey);
-		}
 }

--- a/src/main/java/com/kt/repository/order/OrderRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/order/OrderRepositoryCustom.java
@@ -1,5 +1,7 @@
 package com.kt.repository.order;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -8,4 +10,6 @@ import com.kt.dto.order.response.OrderListResponse;
 
 public interface OrderRepositoryCustom {
 	Page<Order> getOrders(Long userId, Pageable pageable);
+
+	Order getOrderDetailById(Long userId, Long orderId);
 }

--- a/src/main/java/com/kt/repository/order/orderRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/order/orderRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.kt.repository.order;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -60,5 +61,21 @@ public class orderRepositoryCustomImpl implements OrderRepositoryCustom {
 			.fetch().size();
 
 		return new PageImpl<>(content, pageable, total);
+	}
+
+	@Override
+	public Order getOrderDetailById(Long userId, Long orderId) {
+
+		return queryFactory
+			.select(order)
+			.from(order)
+			.join(order.user, user).fetchJoin()
+			.join(user.membership, membership).fetchJoin()
+			.where(
+				order.id.eq(orderId),
+				order.user.id.eq(userId),
+				order.isDeleted.eq(false)
+			)
+			.fetchOne();
 	}
 }

--- a/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryCustom.java
@@ -1,6 +1,11 @@
 package com.kt.repository.orderproduct;
 
+import java.util.List;
+
+import com.kt.domain.orderproduct.OrderProduct;
+
 public interface OrderProductRepositoryCustom {
 	boolean hasInvalidStatusWithVariantId(Long variantId);
 	boolean hasInvalidStatusWithProductId(Long productId);
+	List<OrderProduct> getOrderProductByOrderId(Long orderId);
 }

--- a/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/orderproduct/OrderProductRepositoryCustomImpl.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.kt.domain.order.OrderStatus;
+import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.orderproduct.QOrderProduct;
+import com.kt.domain.product.QProduct;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 public class OrderProductRepositoryCustomImpl implements OrderProductRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 	private final QOrderProduct orderProduct =  QOrderProduct.orderProduct;
+	private final QProduct product =  QProduct.product;
 
 	@Override
 	public boolean hasInvalidStatusWithVariantId(Long variantId) {
@@ -56,5 +59,13 @@ public class OrderProductRepositoryCustomImpl implements OrderProductRepositoryC
 			.fetchFirst() != null;   //존재하는 상품이 있으면 true
 	}
 
+	@Override
+	public List<OrderProduct> getOrderProductByOrderId(Long orderId) {
+		return queryFactory
+			.selectFrom(orderProduct)
+			.join(orderProduct.product, product).fetchJoin()
+			.where(orderProduct.order.id.eq(orderId))
+			.fetch();
+	}
 
 }

--- a/src/main/java/com/kt/repository/payment/PaymentRepository.java
+++ b/src/main/java/com/kt/repository/payment/PaymentRepository.java
@@ -15,7 +15,14 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 		return findByIdAndOrderUserIdAndIsDeletedFalse(paymentId, userId).orElseThrow(() -> new CustomException(errorCode));
 	}
 
+	default Payment findByOrderIdAndIsDeletedFalseOrThorw(Long orderId, ErrorCode errorCode) {
+		return findByOrderIdAndIsDeletedFalse(orderId).orElseThrow(() -> new CustomException(errorCode));
+	}
+
 	@EntityGraph(attributePaths = {"order", "paymentType"})
 	Optional<Payment> findByIdAndOrderUserIdAndIsDeletedFalse(Long paymentId, Long userId);
+
+	@EntityGraph(attributePaths = {"order", "paymentType"})
+	Optional<Payment> findByOrderIdAndIsDeletedFalse(Long orderId);
 }
 

--- a/src/main/java/com/kt/repository/payment/PaymentRepositoryCustom.java
+++ b/src/main/java/com/kt/repository/payment/PaymentRepositoryCustom.java
@@ -1,11 +1,13 @@
 package com.kt.repository.payment;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.kt.dto.payment.PaymentListResponse;
+import com.kt.dto.payment.PaymentOrderInfoResponse;
 
 public interface PaymentRepositoryCustom {
 	Page<PaymentListResponse> getMyAllPayment(Long userId, Pageable pageable);
+
+	PaymentOrderInfoResponse getPaymentDetailByOrderId(Long orderId);
 }

--- a/src/main/java/com/kt/repository/payment/PaymentRepositoryCustomImpl.java
+++ b/src/main/java/com/kt/repository/payment/PaymentRepositoryCustomImpl.java
@@ -5,11 +5,15 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import com.kt.domain.discount.QDiscount;
+import com.kt.domain.membership.QMembership;
 import com.kt.domain.order.QOrder;
+import com.kt.domain.orderproduct.QOrderProduct;
 import com.kt.domain.payment.QPayment;
 import com.kt.domain.paymenttype.QPaymentType;
 import com.kt.domain.user.QUser;
 import com.kt.dto.payment.PaymentListResponse;
+import com.kt.dto.payment.PaymentOrderInfoResponse;
 import com.kt.dto.payment.QPaymentListResponse;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -23,6 +27,9 @@ public class PaymentRepositoryCustomImpl implements  PaymentRepositoryCustom {
 	private final QOrder order = QOrder.order;
 	private final QPaymentType paymentType = QPaymentType.paymentType;
 	private final QUser user = QUser.user;
+	private final QOrderProduct orderProduct = QOrderProduct.orderProduct;
+	private final QMembership membership = QMembership.membership;
+	private final QDiscount discount = QDiscount.discount;
 
 	@Override
 	public Page<PaymentListResponse> getMyAllPayment(Long userId, Pageable pageable) {
@@ -66,6 +73,11 @@ public class PaymentRepositoryCustomImpl implements  PaymentRepositoryCustom {
 			.fetch().size();
 
 		return new PageImpl<>(content, pageable, total);
+	}
+
+	@Override
+	public PaymentOrderInfoResponse getPaymentDetailByOrderId(Long orderId) {
+		return null;
 	}
 
 }

--- a/src/main/java/com/kt/repository/paymenttype/PaymentTypeRepository.java
+++ b/src/main/java/com/kt/repository/paymenttype/PaymentTypeRepository.java
@@ -1,9 +1,12 @@
 package com.kt.repository.paymenttype;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.kt.domain.paymenttype.PaymentType;
 
 public interface PaymentTypeRepository extends JpaRepository<PaymentType, Long> {
 
+	Optional<PaymentType> findByName(String name);
 }

--- a/src/main/java/com/kt/service/discount/DiscountCalcService.java
+++ b/src/main/java/com/kt/service/discount/DiscountCalcService.java
@@ -13,6 +13,7 @@ import com.kt.domain.discount.policy.DiscountPolicy;
 import com.kt.domain.discount.policy.DiscountPolicyFactory;
 import com.kt.domain.discountMembership.DiscountMembership;
 import com.kt.domain.discountProduct.DiscountProduct;
+import com.kt.dto.discount.response.DiscountInfo;
 import com.kt.dto.discount.response.DiscountResult;
 import com.kt.repository.discountmembership.DiscountMembershipRepository;
 import com.kt.repository.discountproduct.DiscountProductRepository;
@@ -94,6 +95,84 @@ public class DiscountCalcService {
 		for (DiscountProduct dp : discountProducts) {
 			result.computeIfAbsent(dp.getProduct().getId(), k -> new ArrayList<>())
 				.add(dp.getDiscount());
+		}
+
+		return result;
+	}
+
+	public List<DiscountInfo> getDiscountsInfoList(Long originalPrice,
+		Discount membershipDiscount,
+		List<Discount> productDiscounts) {
+		List<DiscountInfo> result = new ArrayList<>();
+
+		long maxDiscountPrice = 0L;
+		String selectedCase = "";
+		Discount selectedProductDiscount = null;
+
+		if (membershipDiscount != null) {
+			long membershipOnly = calcDiscount(originalPrice, membershipDiscount);
+			if (membershipOnly > maxDiscountPrice) {
+				maxDiscountPrice = membershipOnly;
+				selectedCase = "MEMBERSHIP_ONLY";
+			}
+		}
+
+		if (productDiscounts != null && !productDiscounts.isEmpty()) {
+			for (Discount productDiscount : productDiscounts) {
+				long productOnly = calcDiscount(originalPrice, productDiscount);
+				if (productOnly > maxDiscountPrice) {
+					maxDiscountPrice = productOnly;
+					selectedCase = "PRODUCT_ONLY";
+					selectedProductDiscount = productDiscount;
+				}
+			}
+		}
+
+		if (membershipDiscount != null && productDiscounts != null) {
+			for (Discount productDiscount : productDiscounts) {
+				if (membershipDiscount.isCombinable() && productDiscount.isCombinable()) {
+					long combined = calcCombined(originalPrice, membershipDiscount, productDiscount);
+					if (combined > maxDiscountPrice) {
+						maxDiscountPrice = combined;
+						selectedCase = "COMBINED";
+						selectedProductDiscount = productDiscount;
+					}
+				}
+			}
+		}
+
+		switch (selectedCase) {
+			case "MEMBERSHIP_ONLY":
+				result.add(new DiscountInfo(
+					membershipDiscount.getName(),
+					"MEMBERSHIP",
+					calcDiscount(originalPrice, membershipDiscount)
+				));
+				break;
+			case "PRODUCT_ONLY":
+				if (selectedProductDiscount != null) {
+					result.add(new DiscountInfo(
+						selectedProductDiscount.getName(),
+						"PRODUCT",
+						calcDiscount(originalPrice, selectedProductDiscount)
+					));
+				}
+				break;
+			case "COMBINED":
+				result.add(new DiscountInfo(
+					membershipDiscount.getName(),
+					"MEMBERSHIP",
+					calcDiscount(originalPrice, membershipDiscount)
+				));
+
+				result.add(new DiscountInfo(
+					selectedProductDiscount.getName(),
+					"PRODUCT",
+					calcDiscount(originalPrice, selectedProductDiscount)
+				));
+				break;
+			default:
+				break;
 		}
 
 		return result;

--- a/src/main/java/com/kt/service/payment/PaymentService.java
+++ b/src/main/java/com/kt/service/payment/PaymentService.java
@@ -1,22 +1,40 @@
 package com.kt.service.payment;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kt.common.exception.CustomException;
 import com.kt.common.exception.ErrorCode;
+import com.kt.common.support.Preconditions;
 import com.kt.domain.discount.Discount;
+import com.kt.domain.discount.policy.DiscountPolicy;
+import com.kt.domain.discount.policy.DiscountPolicyFactory;
+import com.kt.domain.order.Order;
 import com.kt.domain.order.OrderStatus;
+import com.kt.domain.orderproduct.OrderProduct;
 import com.kt.domain.payment.Payment;
+import com.kt.dto.discount.response.DiscountInfo;
 import com.kt.dto.discount.response.DiscountResult;
+import com.kt.dto.order.response.OrderProductResponse;
 import com.kt.dto.payment.PaymentCreateRequest;
 import com.kt.dto.payment.PaymentDetailResponse;
 import com.kt.dto.payment.PaymentListResponse;
+import com.kt.dto.payment.PaymentOrderInfoResponse;
+import com.kt.dto.payment.PaymentTossCancelRequest;
+import com.kt.dto.payment.PaymentTossCancelResponse;
+import com.kt.dto.payment.PaymentTossConfirmRequest;
 import com.kt.repository.order.OrderRepository;
+import com.kt.repository.order.OrderRepositoryCustom;
+import com.kt.repository.orderproduct.OrderProductRepositoryCustom;
 import com.kt.repository.payment.PaymentRepository;
 import com.kt.repository.payment.PaymentRepositoryCustom;
 import com.kt.repository.paymenttype.PaymentTypeRepository;
@@ -37,47 +55,32 @@ public class PaymentService {
 	private final UserRepository userRepository;
 	private final PaymentRepositoryCustom paymentRepositoryCustom;
 	private final DiscountCalcService discountCalcService;
+	private final OrderRepositoryCustom orderRepositoryCustom;
+	private final OrderProductRepositoryCustom orderProductRepositoryCustom;
 
-	public void create(PaymentCreateRequest request, Long userId) {
-		var order = orderRepository.findByIdAndUserIdOrThrow(request.orderId(), userId, ErrorCode.NOT_FOUND_ORDER);
+	public Long create(Map<String, Object> tossResponse, Long userId) {
+		String orderId = tossResponse.get("orderId").toString().split("-")[0];
 
-		var paymentType = paymentTypeRepository.findById(request.paymentTypeId()).orElseThrow();
+		var order = orderRepository.findByIdAndUserIdOrThrow(Long.parseLong(orderId), userId, ErrorCode.NOT_FOUND_ORDER);
 
-		// 멤버십 할인 조회
-		Discount membershipDiscount = discountCalcService.getMembershipDiscount(userId);
+		var paymentType = paymentTypeRepository.findByName(tossResponse.get("method").toString()).orElseThrow();
 
-		// 상품별 할인 조회
-		Map<Long, List<Discount>> productDiscount = discountCalcService.getProductsDiscount(
-			order.getOrderProducts().stream()
-				.map(op -> op.getProduct().getId())
-				.distinct()
-				.toList());
+		long amount = Long.parseLong(tossResponse.get("totalAmount").toString());
 
-		Long totalPrice = 0L;
-
-		for (var orderProduct : order.getOrderProducts()) {
-			DiscountResult result = discountCalcService.calculate(
-				orderProduct.getProduct().getPrice() * orderProduct.getCount(),
-				membershipDiscount,
-				productDiscount.getOrDefault(orderProduct.getProduct().getId(), List.of())
-			);
-
-			totalPrice += result.discountedPrice();
-			System.out.println("총 가격: " + totalPrice);
-		}
-
-		Long finalPrice = totalPrice + DELIVERY_FEE;
 		var payment = new Payment(
 			order,
 			paymentType,
-			totalPrice,
+			amount,
 			DELIVERY_FEE,
-			finalPrice
+			amount - DELIVERY_FEE,
+			tossResponse.get("paymentKey").toString()
 		);
 
-		paymentRepository.save(payment);
+		Payment savedPayment = paymentRepository.save(payment);
 
 		order.updateStatus(OrderStatus.PAID);
+
+		return savedPayment.getId();
 	}
 
 	public Page<PaymentListResponse> getMyAllPayment(Long userId, Pageable pageable) {
@@ -94,6 +97,7 @@ public class PaymentService {
 		return new PaymentDetailResponse(
 			payment.getId(),
 			payment.getOrder().getId(),
+			payment.getPaymentKey(),
 			payment.getOrder().getUser().getLoginId(),
 			payment.getOrder().getUser().getName(),
 			payment.getOrder().getOrderStatus(),
@@ -103,6 +107,150 @@ public class PaymentService {
 			payment.getFinalPrice(),
 			payment.getCreatedAt()
 		);
+	}
+
+	public PaymentOrderInfoResponse getPaymentDetail(Long userId, Long orderId) {
+
+		//1. 주문자 정보 등 조회
+		Order order = orderRepositoryCustom.getOrderDetailById(userId, orderId);
+
+		//2. 주문 상품 정보 조회
+		List<OrderProduct> orderProducts = orderProductRepositoryCustom.getOrderProductByOrderId(orderId);
+
+		//3. 멤버십 할인 및 계산
+		Discount membershipDiscount = discountCalcService.getMembershipDiscount(userId);
+
+		//4. 상품별 할인 및 계산
+		Map<Long, List<Discount>> productDiscounts = discountCalcService.getProductsDiscount(
+			orderProducts.stream()
+			.map(op -> op.getProduct().getId())
+			.distinct()
+			.toList());
+
+		long totalProductPrice = 0L;
+		long totalDiscountPrice = 0L;
+		List<PaymentOrderInfoResponse.OrderProductInfo> orderProductInfos = new ArrayList<>();
+
+
+		for (OrderProduct op : orderProducts) {
+			long originalPrice = op.getProduct().getPrice() * op.getCount();
+
+			DiscountResult result = discountCalcService.calculate(
+				originalPrice,
+				membershipDiscount,
+				productDiscounts.getOrDefault(op.getProduct().getId(), List.of())
+			);
+
+			List<DiscountInfo> discountInfos = discountCalcService.getDiscountsInfoList(
+				originalPrice,
+				membershipDiscount,
+				productDiscounts.getOrDefault(op.getProduct().getId(), List.of())
+			);
+
+			List<PaymentOrderInfoResponse.AppliedDiscountInfo> appliedDiscounts = discountInfos.stream()
+				.map(di -> new PaymentOrderInfoResponse.AppliedDiscountInfo(
+					di.discountName(),
+					di.discountType(),
+					di.discountPrice()
+				))
+				.toList();
+
+			orderProductInfos.add(new PaymentOrderInfoResponse.OrderProductInfo(
+				op.getProduct().getId(),
+				op.getProduct().getName(),
+				op.getVariantId(),
+				op.getCount(),
+				op.getProduct().getPrice(),
+				originalPrice,
+				result.discountPrice(),
+				result.discountedPrice(),
+				appliedDiscounts
+			));
+
+			totalProductPrice += originalPrice;
+			totalDiscountPrice += result.discountPrice();
+		}
+
+		Long finalPrice = totalProductPrice - totalDiscountPrice + DELIVERY_FEE;
+
+		return new PaymentOrderInfoResponse(
+			order.getId(),
+			order.getOrderStatus(),
+			order.getOrderStatus().name(),
+			order.getCreatedAt(),
+			order.getReceiverName(),
+			order.getReceiverPhone(),
+			order.getReceiverAddress(),
+			new PaymentOrderInfoResponse.UserPaymentInfo(
+				order.getUser().getName(),
+				order.getUser().getEmail(),
+				order.getUser().getMobile(),
+				new PaymentOrderInfoResponse.MembershipInfo(
+					order.getUser().getMembership().getLevel()
+				),
+				order.getUser().getMoney()
+			),
+			orderProductInfos,
+			new PaymentOrderInfoResponse.PriceInfo(
+				totalProductPrice,
+				totalDiscountPrice,
+				DELIVERY_FEE,
+				finalPrice
+			)
+		);
+	}
+
+	public PaymentDetailResponse getPaymentByOrderId(Long userId, Long orderId) {
+		var order = orderRepository.findByIdAndUserIdOrThrow(orderId, userId, ErrorCode.NOT_FOUND_ORDER);
+
+		var payment = paymentRepository.findByOrderIdAndIsDeletedFalseOrThorw(order.getId(), ErrorCode.NOT_FOUND_PAYMENT);
+
+		return new PaymentDetailResponse(
+			payment.getId(),
+			payment.getOrder().getId(),
+			payment.getPaymentKey(),
+			payment.getOrder().getUser().getLoginId(),
+			payment.getOrder().getUser().getName(),
+			payment.getOrder().getOrderStatus(),
+			payment.getPaymentType().getName(),
+			payment.getTotalPrice(),
+			payment.getDeliveryFee(),
+			payment.getFinalPrice(),
+			payment.getCreatedAt()
+		);
+	}
+
+	public PaymentTossCancelResponse cancelPayment(PaymentTossCancelRequest request, Long userId, Long paymentId) {
+		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+
+		var payment = paymentRepository.findByIdAndOrderUserIdAndIsDeletedFalseOrThorw(paymentId, user.getId(), ErrorCode.NOT_FOUND_PAYMENT);
+		Preconditions.validate(payment.getTotalPrice().equals(request.cancelAmount()), ErrorCode.CANNOT_CANCEL_PAYMENT_AMOUNT_MISMATCH);
+
+		OrderStatus status = payment.getOrder().getOrderStatus();
+		boolean canCancel = status == OrderStatus.PAID ||
+			status == OrderStatus.PROCESSING ||
+			status == OrderStatus.SHIPPED ||
+			status == OrderStatus.DELIVERED;
+		Preconditions.validate(canCancel, ErrorCode.CANNOT_CANCEL_ORDER);
+
+		payment.delete();
+
+		payment.getOrder().updateStatus(OrderStatus.CANCELLED);
+
+		return new PaymentTossCancelResponse(
+			payment.getFinalPrice(),
+			request.cancelReason(),
+			LocalDateTime.now().toString()
+		);
+
+	}
+
+	public String getPaymentKey(Long paymentId, Long userId) {
+		var user = userRepository.findByIdOrThrow(userId, ErrorCode.NOT_FOUND_USER);
+
+		var payment = paymentRepository.findByIdAndOrderUserIdAndIsDeletedFalseOrThorw(paymentId, user.getId(), ErrorCode.NOT_FOUND_PAYMENT);
+
+		return payment.getPaymentKey();
 	}
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,6 +36,6 @@ logstash:
 
 toss:
   payments:
-    client-key: ${toss.payments.client-key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
-    secret-key: ${toss.payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
-    api-url: ${toss.payments.api-url:https://api.tosspayments.com/v1/payments}
+    client-key: ${payment.client.key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
+    secret-key: ${payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+    api-url: ${payments.api-url:https://api.tosspayments.com/v1/payments}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -33,3 +33,9 @@ server:
 logstash:
   host: ${logstashhost:localhost}
   port: ${logstashport:9601}
+
+toss:
+  payments:
+    client-key: ${toss.payments.client-key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
+    secret-key: ${toss.payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+    api-url: ${toss.payments.api-url:https://api.tosspayments.com/v1/payments}

--- a/src/main/resources/application-integration.yml
+++ b/src/main/resources/application-integration.yml
@@ -38,3 +38,9 @@ jwt:
 
 server:
   port: ${shopping.server.port:8080}
+
+toss:
+  payments:
+    client-key: ${toss.payments.client-key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
+    secret-key: ${toss.payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+    api-url: ${toss.payments.api-url:https://api.tosspayments.com/v1/payments}

--- a/src/main/resources/application-integration.yml
+++ b/src/main/resources/application-integration.yml
@@ -41,6 +41,6 @@ server:
 
 toss:
   payments:
-    client-key: ${toss.payments.client-key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
-    secret-key: ${toss.payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
-    api-url: ${toss.payments.api-url:https://api.tosspayments.com/v1/payments}
+    client-key: ${payment.client.key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
+    secret-key: ${payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+    api-url: ${payments.api-url:https://api.tosspayments.com/v1/payments}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,9 +28,9 @@ slack:
 
 toss:
   payments:
-    client-key: ${toss.payments.client-key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
-    secret-key: ${toss.payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
-    api-url: ${toss.payments.api-url:https://api.tosspayments.com/v1/payments}
+    client-key: ${payment.client.key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
+    secret-key: ${payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+    api-url: ${payments.api-url:https://api.tosspayments.com/v1/payments}
 
 server:
   port: 8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,9 +28,9 @@ slack:
 
 toss:
   payments:
-    client-key: ${toss.payments.client-key}
-    secret-key: ${toss.payments.secret-key}
-    api-url: ${toss.payments.api-url}
+    client-key: ${toss.payments.client-key:test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm}
+    secret-key: ${toss.payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
+    api-url: ${toss.payments.api-url:https://api.tosspayments.com/v1/payments}
 
 server:
   port: 8080

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,5 +26,11 @@ slack:
   bot-token: ${slack.token}
   log-channel: ${slack.channel}
 
+toss:
+  payments:
+    client-key: ${toss.payments.client-key}
+    secret-key: ${toss.payments.secret-key}
+    api-url: ${toss.payments.api-url}
+
 server:
   port: 8080

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,6 +32,6 @@ server:
 
 toss:
   payments:
-    client-key: ${toss.payments.client-key}
-    secret-key: ${toss.payments.secret-key}
-    api-url: ${toss.payments.api-url}
+    client-key: ${payment.client.key}
+    secret-key: ${payments.secret-key}
+    api-url: ${payments.api-url}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,3 +29,9 @@ slack:
 
 server:
   port: ${shopping.server.port}
+
+toss:
+  payments:
+    client-key: ${toss.payments.client-key}
+    secret-key: ${toss.payments.secret-key}
+    api-url: ${toss.payments.api-url}

--- a/src/main/resources/static/order.css
+++ b/src/main/resources/static/order.css
@@ -1,0 +1,221 @@
+/* 추가 스타일 */
+.input-group {
+    margin-bottom: 20px;
+}
+
+.input-group label {
+    display: block;
+    margin-bottom: 8px;
+    color: #333D4B;
+    font-weight: 600;
+    font-size: 15px;
+}
+
+.input-group input {
+    width: 100%;
+    padding: 12px 16px;
+    border: 1px solid #d1d6db;
+    border-radius: 8px;
+    font-size: 14px;
+    box-sizing: border-box;
+    transition: border-color 0.2s;
+}
+
+.input-group input:focus {
+    outline: none;
+    border-color: #3182f6;
+    box-shadow: 0 0 0 3px rgba(49, 130, 246, 0.1);
+}
+
+.order-summary, .delivery-info, .customer-info, .product-list, .payment-summary {
+    background-color: #f8f9fa;
+    padding: 20px;
+    border-radius: 10px;
+    margin-top: 20px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.order-summary h3, .delivery-info h3, .customer-info h3, .product-list h3, .payment-summary h3 {
+    margin-top: 0;
+    margin-bottom: 15px;
+    color: #333D4B;
+    font-size: 18px;
+    border-bottom: 2px solid #3182f6;
+    padding-bottom: 10px;
+}
+
+.order-summary p, .delivery-info p, .customer-info p {
+    margin: 10px 0;
+    color: #4e5968;
+    line-height: 1.8;
+}
+
+.product-list table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 15px;
+    background-color: white;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.product-list table th {
+    background-color: #3182f6;
+    color: white;
+    padding: 14px 12px;
+    text-align: left;
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.product-list table td {
+    padding: 14px 12px;
+    border-bottom: 1px solid #e5e8eb;
+    color: #4e5968;
+    font-size: 14px;
+}
+
+.product-list table tr:last-child td {
+    border-bottom: none;
+}
+
+.product-list table tbody tr:hover {
+    background-color: #f8f9fa;
+    transition: background-color 0.2s;
+}
+
+.payment-summary {
+    background: linear-gradient(135deg, #e8f3ff 0%, #f0f7ff 100%);
+    border: 2px solid #3182f6;
+}
+
+.price-row {
+    display: flex;
+    justify-content: space-between;
+    margin: 12px 0;
+    color: #4e5968;
+    font-size: 15px;
+    padding: 8px 0;
+}
+
+.price-row.discount {
+    color: #f04452;
+    font-weight: 600;
+}
+
+.price-row.final {
+    font-size: 20px;
+    color: #191f28;
+    margin-top: 15px;
+    padding-top: 15px;
+    border-top: 2px solid #3182f6;
+}
+
+.payment-summary hr {
+    display: none;
+}
+
+#order-details {
+    display: none;
+}
+
+.status-badge {
+    display: inline-block;
+    padding: 6px 14px;
+    border-radius: 16px;
+    font-size: 13px;
+    font-weight: 600;
+    background-color: #e8f3ff;
+    color: #1b64da;
+}
+
+.button-group {
+    display: flex;
+    gap: 10px;
+    margin-top: 20px;
+}
+
+.discount-text {
+    color: #f04452;
+    font-weight: 600;
+}
+
+.loading {
+    text-align: center;
+    padding: 20px;
+    color: #8b95a1;
+}
+
+@media (max-width: 768px) {
+    .product-list table {
+        font-size: 12px;
+    }
+
+    .product-list table th,
+    .product-list table td {
+        padding: 10px 8px;
+    }
+
+    .price-row {
+        font-size: 14px;
+    }
+
+    .price-row.final {
+        font-size: 18px;
+    }
+}
+
+/* 할인 정보 표시 스타일 */
+.discount-details {
+    background-color: #fff3cd;
+    padding: 8px 12px;
+    margin: 5px 0;
+    border-left: 3px solid #ffc107;
+    font-size: 13px;
+}
+.discount-item {
+    display: flex;
+    justify-content: space-between;
+    margin: 4px 0;
+    color: #856404;
+}
+.discount-item .discount-name {
+    font-weight: 600;
+}
+.discount-item .discount-amount {
+    color: #d9534f;
+    font-weight: 700;
+}
+.product-row td {
+    border-bottom: none !important;
+}
+.discount-row td {
+    padding: 0 !important;
+    border-bottom: 1px solid #e5e8eb !important;
+}
+.no-discount-info {
+    color: #6c757d;
+    font-style: italic;
+    font-size: 12px;
+    padding: 8px 12px;
+}
+
+.input-group {
+    margin-bottom: 15px;
+}
+
+.input-group label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+    color: #333;
+}
+
+#cancel-button {
+    background-color: #dc3545;
+}
+
+#cancel-button:hover {
+    background-color: #c82333;
+}

--- a/src/main/resources/static/payment-fail.html
+++ b/src/main/resources/static/payment-fail.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="kr">
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+        <link rel="stylesheet" type="text/css" href="style.css" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>결제 실패</title>
+    </head>
+    <body>
+        <div id="info" class="box_section" style="width: 600px">
+            <img width="100px" src="https://static.toss.im/lotties/error-spot-no-loop-space-apng.png" />
+            <h2>결제를 실패했어요</h2>
+
+            <div class="p-grid typography--p" style="margin-top: 50px">
+                <div class="p-grid-col text--left"><b>에러메시지</b></div>
+                <div class="p-grid-col text--right" id="message"></div>
+            </div>
+            <div class="p-grid typography--p" style="margin-top: 10px">
+                <div class="p-grid-col text--left"><b>에러코드</b></div>
+                <div class="p-grid-col text--right" id="code"></div>
+            </div>
+            <div class="p-grid">
+                <button class="button p-grid-col5" onclick="location.href='https://docs.tosspayments.com/guides/v2/payment-widget/integration';">연동 문서</button>
+                <button class="button p-grid-col5" onclick="location.href='https://discord.gg/A4fRFXQhRu';" style="background-color: #e8f3ff; color: #1b64da">실시간 문의</button>
+            </div>
+        </div>
+
+        <script>
+            const urlParams = new URLSearchParams(window.location.search);
+
+            const codeElement = document.getElementById("code");
+            const messageElement = document.getElementById("message");
+
+            codeElement.textContent = urlParams.get("code") || "UNKNOWN_ERROR";
+            messageElement.textContent = urlParams.get("message") || "알 수 없는 오류가 발생했습니다.";
+        </script>
+    </body>
+</html>

--- a/src/main/resources/static/payment-success.html
+++ b/src/main/resources/static/payment-success.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="kr">
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+        <link rel="stylesheet" type="text/css" href="style.css" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>결제 성공</title>
+    </head>
+    <body>
+        <div class="box_section" style="width: 600px">
+            <img width="100px" src="https://static.toss.im/illusts/check-blue-spot-ending-frame.png" />
+            <h2>결제를 완료했어요</h2>
+
+            <div class="p-grid" style="margin-top: 30px">
+                <button class="button p-grid-col5" onclick="location.href='https://docs.tosspayments.com/guides/v2/payment-widget/integration';">연동 문서</button>
+                <button class="button p-grid-col5" onclick="location.href='https://discord.gg/A4fRFXQhRu';" style="background-color: #e8f3ff; color: #1b64da">실시간 문의</button>
+            </div>
+            <div class="p-grid typography--p" style="margin-top: 50px">
+                <div class="p-grid-col text--left"><b>결제금액</b></div>
+                <div class="p-grid-col text--right" id="amount"></div>
+            </div>
+            <div class="p-grid typography--p" style="margin-top: 10px">
+                <div class="p-grid-col text--left"><b>주문번호</b></div>
+                <div class="p-grid-col text--right" id="orderId"></div>
+            </div>
+            <div class="p-grid typography--p" style="margin-top: 10px">
+                <div class="p-grid-col text--left"><b>paymentKey</b></div>
+                <div class="p-grid-col text--right" id="paymentKey" style="white-space: initial; width: 250px"></div>
+            </div>
+        </div>
+
+        <div class="box_section" style="width: 600px; text-align: left">
+            <b>Response Data :</b>
+            <div id="response" style="white-space: initial"></div>
+        </div>
+        <script>
+            // 쿼리 파라미터 값이 결제 요청할 때 보낸 데이터와 동일한지 반드시 확인
+            // 클라이언트에서 결제 금액을 조작하는 행위를 방지할 수 있음
+            const urlParams = new URLSearchParams(window.location.search);
+
+            // 백엔드 API 호출
+            async function confirmPayment() {
+                const requestData = {
+                    paymentKey: urlParams.get("paymentKey"),
+                    orderId: urlParams.get("orderId"),
+                    amount: urlParams.get("amount")
+                };
+
+                const accessToken = sessionStorage.getItem('paymentAccessToken');
+
+                if (!accessToken) {
+                    alert('인증 토큰이 없습니다. 다시 시도해주세요.');
+                    window.location.href = '/payment-test.html';
+                    return;
+                }
+
+                try {
+                    const response = await fetch("/api/payments/confirm", {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            "Authorization": `Bearer ${accessToken}`
+                        },
+                        body: JSON.stringify(requestData)
+                    });
+
+                    const json = await response.json();
+
+                    if (!response.ok) {
+                        const errorMessage = json.message || "결제 승인에 실패했습니다.";
+                        const errorCode = json.code || "UNKNOWN_ERROR";
+
+                        alert("결제 승인 실패: " + errorMessage);
+
+                        const params = new URLSearchParams({
+                            message: errorMessage,
+                            code: errorCode
+                        });
+
+                        window.location.href = `/payment-fail.html?${params.toString()}`;
+
+                        return;
+                    }
+
+                    sessionStorage.removeItem('paymentAccessToken');
+
+                    document.getElementById("response").innerHTML = `<pre>${JSON.stringify(json, null, 4)}</pre>`;
+
+                    if (json.paymentId) {
+                        const paymentIdDiv = document.createElement('div');
+                        paymentIdDiv.className = 'p-grid typography--p';
+                        paymentIdDiv.style.marginTop = '10px';
+                        paymentIdDiv.innerHTML = `
+                <div class="p-grid-col text--left"><b>결제 ID</b></div>
+                <div class="p-grid-col text--right">${json.paymentId}</div>
+            `;
+                        document.querySelector('.box_section').appendChild(paymentIdDiv);
+                    }
+                } catch (error) {
+                    alert("결제 확인 중 오류 발생: " + error);
+
+                    const params = new URLSearchParams({
+                        message: error.message || "알 수 없는 오류가 발생했습니다.",
+                        code: "NETWORK_ERROR"
+                    });
+
+                    window.location.href = `/payment-fail.html?${params.toString()}`;
+                }
+            }
+
+            confirmPayment();
+
+            const paymentKeyElement = document.getElementById("paymentKey");
+            const orderIdElement = document.getElementById("orderId");
+            const amountElement = document.getElementById("amount");
+
+            orderIdElement.textContent = urlParams.get("orderId");
+            amountElement.textContent = urlParams.get("amount") + "원";
+            paymentKeyElement.textContent = urlParams.get("paymentKey");
+        </script>
+    </body>
+</html>

--- a/src/main/resources/static/payment-test.html
+++ b/src/main/resources/static/payment-test.html
@@ -1,0 +1,507 @@
+<!DOCTYPE html>
+<html lang="kr">
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="https://static.toss.im/icons/png/4x/icon-toss-logo.png" />
+    <link rel="stylesheet" type="text/css" href="style.css" />
+    <link rel="stylesheet" type="text/css" href="order.css" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Toss 결제 테스트</title>
+    <script src="https://js.tosspayments.com/v2/standard"></script>
+</head>
+<body>
+<div class="wrapper">
+    <!-- 주문 정보 입력 섹션 -->
+    <div class="box_section" style="padding: 40px 30px; margin-top: 30px;">
+        <h2 style="margin-top: 0; color: #333D4B;">📦 주문 정보 조회</h2>
+
+        <div class="input-group">
+            <label for="orderId">주문 ID</label>
+            <input type="number" id="orderId" placeholder="DB에 생성된 Order ID를 입력하세요 (예: 123)" />
+        </div>
+
+        <div class="input-group">
+            <label for="accessToken">Token</label>
+            <input type="text" id="accessToken" placeholder="JWT Token을 입력하세요" />
+        </div>
+
+        <button class="button" onclick="fetchOrderInfo()" style="width: 100%; padding: 15px; font-size: 16px;">
+            🔍 정보 가져오기
+        </button>
+    </div>
+    <!-- 주문 상세 정보 섹션 (초기에는 숨김) -->
+    <div id="order-details">
+        <!-- 주문 정보 -->
+        <div class="box_section" style="padding: 40px 30px; margin-top: 20px;">
+            <div class="order-summary">
+                <h3>📋 주문 정보</h3>
+                <p><b>주문번호:</b> <span id="display-order-id">-</span></p>
+                <p><b>주문일시:</b> <span id="display-order-date">-</span></p>
+                <p><b>주문상태:</b> <span id="display-order-status" class="status-badge">-</span></p>
+            </div>
+
+            <!-- 배송지 정보 -->
+            <div class="delivery-info">
+                <h3>🚚 배송지 정보</h3>
+                <p><b>수령인:</b> <span id="display-receiver-name">-</span></p>
+                <p><b>연락처:</b> <span id="display-receiver-phone">-</span></p>
+                <p><b>배송주소:</b> <span id="display-receiver-address">-</span></p>
+            </div>
+
+            <!-- 주문자 정보 -->
+            <div class="customer-info">
+                <h3>👤 주문자 정보</h3>
+                <p><b>이름:</b> <span id="display-user-name">-</span></p>
+                <p><b>이메일:</b> <span id="display-user-email">-</span></p>
+                <p><b>휴대폰:</b> <span id="display-user-mobile">-</span></p>
+                <p><b>회원등급:</b> <span id="display-user-membership">-</span></p>
+                <p><b>보유금액:</b> <span id="display-user-money">-</span>원</p>
+            </div>
+
+            <!-- 주문 상품 목록 -->
+            <div class="product-list">
+                <h3>🛍️ 주문 상품 목록</h3>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>상품명</th>
+                        <th style="text-align: center;">수량</th>
+                        <th style="text-align: right;">단가</th>
+                        <th style="text-align: right;">합계</th>
+                        <th style="text-align: right;">최종가</th>
+                    </tr>
+                    </thead>
+                    <tbody id="product-table-body">
+                    <tr>
+                        <td colspan="4" class="loading">주문 정보를 불러오는 중...</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- 결제 금액 요약 -->
+            <div class="payment-summary">
+                <h3>💰 결제 금액 요약</h3>
+                <div class="price-row">
+                    <span>총 상품 금액:</span>
+                    <span id="display-total-product-price">0원</span>
+                </div>
+                <div class="price-row discount">
+                    <span>총 할인 금액:</span>
+                    <span id="display-total-discount">0원</span>
+                </div>
+                <div class="price-row">
+                    <span>배송비:</span>
+                    <span id="display-delivery-fee">0원</span>
+                </div>
+                <div class="price-row final">
+                    <span><b>최종 결제 금액:</b></span>
+                    <span id="display-final-price"><b>0원</b></span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="box_section" id="payment-section" style="padding: 40px 30px 50px 30px; margin-top: 30px; margin-bottom: 50px; display: none;">
+
+        <div id="payment-widget-area">
+            <h2>결제 테스트</h2>
+
+            <!-- 결제 UI -->
+            <div id="payment-method"></div>
+
+            <!-- 이용약관 -->
+            <div id="agreement"></div>
+
+            <!-- 결제하기 버튼 -->
+            <div class="result wrapper">
+                <button class="button" id="payment-button" style="margin-top: 30px; padding: 15px 30px;">
+                    결제하기
+                </button>
+            </div>
+        </div>
+
+        <div id="cancel-payment-area" style="display: none;">
+            <h2>결제 취소</h2>
+
+            <div style="background-color: #f8f9fa; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
+                <p style="margin: 0; color: #666;">
+                    <strong>결제 정보</strong><br>
+                    결제 금액: <span id="cancel-payment-amount" style="font-size: 18px; color: #333; font-weight: bold;">0원</span><br>
+                    결제 일시: <span id="cancel-payment-date">-</span>
+                </p>
+            </div>
+
+            <div class="input-group" style="margin-bottom: 20px;">
+                <label for="cancelReason">취소 사유 <span style="color: red;">*</span></label>
+                <textarea
+                        id="cancelReason"
+                        placeholder="취소 사유를 입력해주세요 (필수)"
+                        rows="4"
+                        style="width: 100%; padding: 10px; border: 1px solid #ddd; border-radius: 4px; resize: vertical;"
+                ></textarea>
+            </div>
+
+            <div class="result wrapper">
+                <button class="button" id="cancel-button" onclick="cancelPayment()"
+                        style="margin-top: 10px; padding: 15px 30px; background-color: #dc3545;">
+                    결제 취소하기
+                </button>
+            </div>
+
+            <p style="margin-top: 15px; color: #666; font-size: 14px;">
+                ⚠️ 결제 취소는 배송 준비 중까지만 가능합니다.<br>
+                배송이 시작된 이후에는 반품/환불 절차를 이용해주세요.
+            </p>
+        </div>
+
+        <!-- 취소 불가 안내 영역 (CANCELLED, REFUNDED 등) -->
+        <div id="cannot-action-area" style="display: none; text-align: center; padding: 40px 20px;">
+            <h2 style="color: #666;">주문 처리 완료</h2>
+            <p id="cannot-action-message" style="color: #999; font-size: 16px;"></p>
+        </div>
+
+    </div>
+
+    <script>
+        let orderData = null;
+        let paymentData = null;
+
+        async function fetchOrderInfo() {
+            const orderId = document.getElementById('orderId').value.trim();
+            const accessToken = document.getElementById('accessToken').value.trim();
+
+            if (!orderId) {
+                alert('주문 ID를 입력해주세요.');
+                return;
+            }
+
+            if (!accessToken) {
+                alert('Access Token을 입력해주세요.');
+                return;
+            }
+
+            try {
+                const response = await fetch(`/api/payments/order/${orderId}/info`, {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${accessToken}`
+                    }
+                });
+
+                if (!response.ok) {
+                    if (response.status === 401) {
+                        alert('인증에 실패했습니다. Token을 확인해주세요.');
+                        return;
+                    }
+                    if (response.status === 403) {
+                        alert('접근 권한이 없습니다.');
+                        return;
+                    }
+                    if (response.status === 404) {
+                        alert('주문을 찾을 수 없습니다.');
+                        return;
+                    }
+                    throw new Error('주문 정보를 가져올 수 없습니다.');
+                }
+
+                const result = await response.json();
+                orderData = result.data;
+
+                // 화면에 주문 정보 표시
+                displayOrderInfo(orderData);
+
+                // 주문 상세 섹션 표시
+                document.getElementById('order-details').style.display = 'block';
+
+                // 결제 위젯 초기화
+                await handlePaymentSection(orderData);
+
+                // 스크롤 이동
+                setTimeout(() => {
+                    document.getElementById('order-details').scrollIntoView({ behavior: 'smooth' });
+                }, 100);
+
+            } catch (error) {
+                // 로직상 errorcode가 모두 400이고 customcode가 없으므로 일반 오류로 처리
+                console.error('주문 정보 조회 실패:', error);
+                alert('결제가 이미 완료되었거나 결제를 진행할 수 없는 주문입니다.');
+            }
+        }
+
+        async function handlePaymentSection(data) {
+            const paymentSection = document.getElementById('payment-section');
+            const paymentWidgetArea = document.getElementById('payment-widget-area');
+            const cancelPaymentArea = document.getElementById('cancel-payment-area');
+            const cannotActionArea = document.getElementById('cannot-action-area');
+
+            // 모든 영역 초기화
+            paymentWidgetArea.style.display = 'none';
+            cancelPaymentArea.style.display = 'none';
+            cannotActionArea.style.display = 'none';
+            paymentSection.style.display = 'block';
+
+            const orderStatus = data.orderStatus;
+
+            // ORDERED 상태: 결제 위젯 표시
+            if (orderStatus === 'ORDERED') {
+                paymentWidgetArea.style.display = 'block';
+                await initPaymentWidget(data);
+            }
+            // PAID, PROCESSING, SHIPPED, DELIVERED: 결제 취소 버튼 표시
+            else if (['PAID', 'PROCESSING', 'SHIPPED', 'DELIVERED'].includes(orderStatus)) {
+                cancelPaymentArea.style.display = 'block';
+                await loadPaymentInfo(data.orderId);
+            }
+            // CANCELLED, REFUNDED 등: 안내 메시지만 표시
+            else if (['CANCELLED', 'REFUNDED', 'RETURN_REQUESTED', 'RETURNED', 'REFUND_REQUESTED'].includes(orderStatus)) {
+                cannotActionArea.style.display = 'block';
+                const messageElement = document.getElementById('cannot-action-message');
+
+                if (orderStatus === 'CANCELLED') {
+                    messageElement.textContent = '이 주문은 취소되었습니다.';
+                } else if (orderStatus === 'REFUNDED') {
+                    messageElement.textContent = '이 주문은 환불 완료되었습니다.';
+                } else {
+                    messageElement.textContent = `주문 상태: ${data.orderStatusDescription}`;
+                }
+            }
+        }
+
+        async function loadPaymentInfo(orderId) {
+            try {
+                const accessToken = document.getElementById('accessToken').value.trim();
+
+                // 결제 목록 조회 후 해당 주문의 결제 정보 찾기
+                const response = await fetch(`/api/payments/order/${orderId}`, {
+                    method: 'GET',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${accessToken}`
+                    }
+                });
+
+                if (!response.ok) {
+                    console.error('결제 정보 조회 실패');
+                    return;
+                }
+
+                const result = await response.json();
+                paymentData = result.data;
+
+                if (paymentData) {
+                    // 결제 정보 표시
+                    document.getElementById('cancel-payment-amount').textContent =
+                        paymentData.totalPrice.toLocaleString() + '원';
+                    document.getElementById('cancel-payment-date').textContent =
+                        new Date(paymentData.createdAt).toLocaleString('ko-KR');
+                }
+            } catch (error) {
+                console.error('결제 정보 로딩 실패:', error);
+            }
+        }
+
+        async function cancelPayment() {
+            const cancelReason = document.getElementById('cancelReason').value.trim();
+            const accessToken = document.getElementById('accessToken').value.trim();
+
+            if (!cancelReason) {
+                alert('취소 사유를 입력해주세요.');
+                return;
+            }
+
+            if (!paymentData) {
+                alert('결제 정보를 찾을 수 없습니다.');
+                return;
+            }
+
+            if (!confirm(`정말로 결제를 취소하시겠습니까?\n\n취소 금액: ${paymentData.totalPrice.toLocaleString()}원\n취소 사유: ${cancelReason}`)) {
+                return;
+            }
+
+            try {
+                console.log(paymentData.totalPrice);
+                console.log(cancelReason);
+                const response = await fetch(`/api/payments/${paymentData.id}/cancel`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${accessToken}`
+                    },
+                    body: JSON.stringify({
+                        cancelReason: cancelReason,
+                        cancelAmount: paymentData.totalPrice
+                    })
+                });
+
+                if (!response.ok) {
+                    const errorData = await response.json();
+                    alert('결제 취소 실패: ' + (errorData.message || '오류가 발생했습니다.'));
+                    return;
+                }
+
+                const result = await response.json();
+                alert('✅ 결제가 성공적으로 취소되었습니다.');
+
+                // 페이지 새로고침하여 최신 상태 반영
+                location.reload();
+
+            } catch (error) {
+                console.error('결제 취소 중 오류:', error);
+                alert('결제 취소 중 오류가 발생했습니다.');
+            }
+        }
+
+        // 주문 정보 화면에 표시
+        function displayOrderInfo(data) {
+            // 주문 정보
+            document.getElementById('display-order-id').textContent = data.orderId;
+            document.getElementById('display-order-date').textContent =
+                new Date(data.createdAt).toLocaleString('ko-KR');
+            document.getElementById('display-order-status').textContent =
+                `${data.orderStatus} (${data.orderStatusDescription})`;
+
+            // 배송지 정보
+            document.getElementById('display-receiver-name').textContent = data.receiverName;
+            document.getElementById('display-receiver-phone').textContent = data.receiverPhone;
+            document.getElementById('display-receiver-address').textContent = data.receiverAddress;
+
+            // 주문자 정보
+            document.getElementById('display-user-name').textContent = data.user.name;
+            document.getElementById('display-user-email').textContent = data.user.email;
+            document.getElementById('display-user-mobile').textContent = data.user.mobile;
+            document.getElementById('display-user-membership').textContent = data.user.membership.level;
+            document.getElementById('display-user-money').textContent = data.user.money.toLocaleString();
+
+            // 주문 상품 목록
+            const tbody = document.getElementById('product-table-body');
+            tbody.innerHTML = '';
+
+            data.orderProducts.forEach(product => {
+                console.log(product);
+                // 상품 기본 정보 행
+                const productRow = tbody.insertRow();
+                productRow.className = 'product-row';
+                productRow.innerHTML = `
+                            <td>${product.productName}</td>
+                            <td style="text-align: center;">${product.productCount}개</td>
+                            <td style="text-align: right;">${product.price.toLocaleString()}원</td>
+                            <td style="text-align: right;"><b>${product.totalPrice.toLocaleString()}원</b></td>
+                            <td style="text-align: right;">${product.discountedPrice.toLocaleString()}원</td>
+                        `;
+
+                // 할인 상세 정보 행
+                const discountRow = tbody.insertRow();
+                discountRow.className = 'discount-row';
+                const discountCell = discountRow.insertCell(0);
+                discountCell.colSpan = 5;
+
+                if (product.appliedDiscounts && product.appliedDiscounts.length > 0) {
+                    let discountHtml = '<div class="discount-details">';
+                    discountHtml += '<div style="font-weight: 700; margin-bottom: 5px; color: #333;">🏷️ 적용된 할인:</div>';
+
+                    product.appliedDiscounts.forEach(discount => {
+                        const typeLabel = discount.discountType === 'MEMBERSHIP' ? '🎖️ 멤버십' : '🎁 상품';
+                        discountHtml += `
+                                    <div class="discount-item">
+                                        <span class="discount-name">${typeLabel} ${discount.discountName}</span>
+                                        <span class="discount-amount">-${discount.discountAmount.toLocaleString()}원</span>
+                                    </div>
+                                `;
+                    });
+
+                    // 총 할인 금액
+                    discountHtml += `
+                                <div class="discount-item" style="border-top: 1px solid #ffc107; margin-top: 5px; padding-top: 5px;">
+                                    <span class="discount-name">총 할인</span>
+                                    <span class="discount-amount">-${product.discountPrice.toLocaleString()}원</span>
+                                </div>
+                            `;
+                    discountHtml += '</div>';
+                    discountCell.innerHTML = discountHtml;
+                } else {
+                    discountCell.innerHTML = '<div class="no-discount-info">적용된 할인이 없습니다.</div>';
+                }
+            });
+
+            // 결제 금액 요약
+            document.getElementById('display-total-product-price').textContent =
+                data.priceInfo.totalProductPrice.toLocaleString() + '원';
+            document.getElementById('display-total-discount').textContent =
+                '-' + data.priceInfo.totalDiscountPrice.toLocaleString() + '원';
+            document.getElementById('display-delivery-fee').textContent =
+                data.priceInfo.deliveryFee.toLocaleString() + '원';
+            document.getElementById('display-final-price').innerHTML =
+                '<b>' + data.priceInfo.finalPrice.toLocaleString() + '원</b>';
+        }
+
+        async function initPaymentWidget() {
+            try {
+                const keyResponse = await fetch("/api/payments/client-key");
+                if (!keyResponse.ok) {
+                    throw new Error("클라이언트 키를 가져올 수 없습니다.");
+                }
+
+                const keyData = await keyResponse.json();
+                const clientKey = keyData.data.clientKey;
+                const customerKey = generateRandomString();
+
+                // Toss Payments 초기화
+                const tossPayments = TossPayments(clientKey);
+                const widgets = tossPayments.widgets({ customerKey });
+
+                // 결제 금액 설정
+                await widgets.setAmount({
+                    currency: "KRW",
+                    value: orderData.priceInfo.finalPrice
+                });
+
+                // 결제 UI 렌더링
+                await widgets.renderPaymentMethods({
+                    selector: "#payment-method",
+                    variantKey: "DEFAULT"
+                });
+
+                // 이용약관 렌더링
+                await widgets.renderAgreement({
+                    selector: "#agreement",
+                    variantKey: "AGREEMENT"
+                });
+
+                // 결제하기 버튼
+                const button = document.getElementById("payment-button");
+                button.onclick = null; // 기존 이벤트 제거
+                button.addEventListener("click", async function () {
+                    try {
+
+                        const accessToken = document.getElementById('accessToken').value.trim();
+                        sessionStorage.setItem('paymentAccessToken', accessToken);
+
+                        await widgets.requestPayment({
+                            orderId: orderData.orderId.toString() + "-" + generateRandomString(),
+                            orderName: `주문 ${orderData.orderId}번`,
+                            successUrl: window.location.origin + "/payment-success.html",
+                            failUrl: window.location.origin + "/payment-fail.html",
+                            customerEmail: orderData.user.email,
+                            customerName: orderData.user.name,
+                            customerMobilePhone: orderData.user.mobile.replace(/-/g, "")
+                        });
+                    } catch (error) {
+                        console.error("결제 요청 실패:", error);
+                        alert("결제 요청을 취소하였습니다.");
+                    }
+                });
+            } catch (error) {
+                console.error("결제 위젯 초기화 실패:", error);
+                //alert("결제 위젯 초기화 중 오류가 발생했습니다.");
+            }
+        }
+
+        function generateRandomString() {
+            return window.btoa(Math.random()).slice(0, 20);
+        }
+    </script>
+</div>
+</body>
+</html>

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,0 +1,251 @@
+body {
+    background-image: url('https://static.toss.im/ml-illust/img-back_005.jpg');
+}
+.p {
+    padding: 0;
+    margin: 0;
+    font-family: Toss Product Sans, -apple-system, BlinkMacSystemFont,
+    Bazier Square, Noto Sans KR, Segoe UI, Apple SD Gothic Neo, Roboto,
+    Helvetica Neue, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji,
+    Segoe UI Symbol, Noto Color Emoji;
+    color: #4e5968;
+    word-break: keep-all;
+    word-wrap: break-word;
+}
+.h4 {
+    font-size: 20px;
+    font-weight: 700;
+    color: #333D4B;
+}
+.wrapper {
+    max-width: 800px;
+    margin: 0 auto;
+}
+.button {
+    color: #f9fafb;
+    background-color: #3182f6;
+    margin: 0;
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 18px;
+    white-space: nowrap;
+    text-align: center;
+    /* vertical-align: middle; */
+    cursor: pointer;
+    border: 0 solid transparent;
+    user-select: none;
+    transition: background 0.2s ease, color 0.1s ease;
+    text-decoration: none;
+    border-radius: 7px;
+    padding: 11px 16px;
+}
+.button:hover {
+    color: #fff;
+    background-color: #1b64da;
+}
+.title {
+    margin: 0 0 4px;
+    font-size: 24px;
+    font-weight: 600;
+    color: #4e5968;
+}
+.result {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    text-wrap: balance;
+}
+.box_section {
+    background-color: white;
+    border-radius: 10px;
+    box-shadow: 0 10px 20px rgb(0 0 0 / 1%), 0 6px 6px rgb(0 0 0 / 6%);
+    padding: 40px 30px 50px 30px;
+    margin-top:30px;
+    margin-bottom:50px;
+    color: #333D4B
+}
+:root {
+    --checkable-size: 20px;
+    --checkable-input-top: 3px;
+    --checkable-input-left: 5px;
+    --checkable-input-width: 14px;
+    --checkable-input-height: 10px;
+    --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    --checkable-label-text-padding: 8px;
+    --indeterminate-checkable-input-top: 7px;
+    --indeterminate-checkable-input-left: 5px;
+    --indeterminate-checkable-input-width: 14px
+}
+
+:root .checkable--small {
+    --checkable-size: 20px;
+    --checkable-input-top: 2px;
+    --checkable-input-left: 4px;
+    --checkable-input-width: 12px;
+    --checkable-input-height: 9px;
+    --checkable-input-svg: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.286 3.645l3.536 3.536 5.892-5.893' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    --indeterminate-checkable-input-top: 5px;
+    --indeterminate-checkable-input-left: 4px;
+    --indeterminate-checkable-input-width: 12px
+}
+
+.checkable {
+    position: relative;
+    display: flex
+}
+
+.checkable+.checkable {
+    margin-top: 12px
+}
+
+.checkable--inline {
+    display: inline-block
+}
+
+.checkable--inline+.checkable--inline {
+    margin-top: 0;
+    margin-left: 18px
+}
+
+.checkable__label {
+    display: inline-block;
+    max-width: 100%;
+    min-height: 20px;
+    min-height: var(--checkable-size);
+    line-height: 1.6;
+    padding-left: 20px;
+    padding-left: var(--checkable-size);
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    color: #4e5968;
+    color: var(--grey700);
+    cursor: pointer
+}
+
+.checkable__input {
+    position: absolute;
+    margin: 0 0 0 -20px;
+    margin: 0 0 0 calc(var(--checkable-size)*-1);
+    top: 4px;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    border: none;
+    cursor: pointer
+}
+
+.checkable__input:after,.checkable__input:before {
+    content: "";
+    position: absolute
+}
+
+.checkable__input:before {
+    top: -4px;
+    left: 0;
+    width: 20px;
+    width: var(--checkable-size);
+    height: 20px;
+    height: var(--checkable-size);
+    border: 2px solid #d1d6db;
+    border: 2px solid #d1d6db;
+    background-color: #fff;
+    background-color: white;
+    transition: border-color .1s ease,background-color .1s ease
+}
+
+.checkable__input:after {
+    opacity: 0;
+    transition: opacity .1s ease;
+    top: 3px;
+    top: var(--checkable-input-top);
+    left: 5px;
+    left: var(--checkable-input-left);
+    width: 14px;
+    width: var(--checkable-input-width);
+    height: 10px;
+    height: var(--checkable-input-height);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.343 4.574l4.243 4.243 7.07-7.071' fill='transparent' stroke-width='2' stroke='%23FFF' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-image: var(--checkable-input-svg);
+    background-repeat: no-repeat
+}
+
+.checkable__input[type=checkbox]:indeterminate:after {
+    top: 7px;
+    top: var(--indeterminate-checkable-input-top);
+    left: 5px;
+    left: var(--indeterminate-checkable-input-left);
+    width: 14px;
+    width: var(--indeterminate-checkable-input-width);
+    height: 0;
+    border: 1px solid #fff;
+    border: 1px solid var(--white);
+    border-radius: 1px;
+    transform: rotate(0)
+}
+
+.checkable__input:focus {
+    outline: 0
+}
+
+.checkable__input:focus:before,.checkable__input:hover:before {
+    background-color: #e8f3ff;
+    background-color: #e8f3ff;
+    border-color: #3182f6;
+    border-color: #3182f6
+}
+
+.checkable__input:checked:before,.checkable__input[type=checkbox]:indeterminate:before {
+    border-color: #3182f6;
+    border-color: #3182f6;
+    background-color: #3182f6;
+    background-color: #3182f6
+}
+
+.checkable__input:checked:after,.checkable__input[type=checkbox]:indeterminate:after {
+    opacity: 1
+}
+
+.checkable__input:disabled:before {
+    background-color: #f2f4f6;
+    background-color: var(--grey100);
+    border-color: rgba(0,23,51,.02);
+    border-color: var(--greyOpacity50)
+}
+
+.checkable__input:disabled:checked:before,.checkable__input:disabled[type=checkbox]:indeterminate:before {
+    background-color: #e5e8eb;
+    background-color: var(--grey200);
+    border-color: #e5e8eb;
+    border-color: var(--grey200)
+}
+
+.checkable__input[type=checkbox]:before {
+    border-radius: 6px
+}
+
+.checkable__input[type=radio]:before {
+    border-radius: 12px
+}
+
+.checkable__label-text {
+    display: inline-block;
+    padding-left: 13px;
+    color: #4e5968;
+
+    /* padding-left: var(--checkable-label-text-padding) */
+}
+
+.checkable--disabled>.checkable__input {
+    cursor: not-allowed
+}
+
+.checkable--disabled>.checkable__label {
+    color: #b0b8c1;
+    color: var(--grey400);
+    cursor: not-allowed
+}
+
+.checkable--read-only {
+    pointer-events: none
+}

--- a/src/test/java/com/kt/service/payment/PaymentServiceTest.java
+++ b/src/test/java/com/kt/service/payment/PaymentServiceTest.java
@@ -3,6 +3,7 @@ package com.kt.service.payment;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,8 +25,6 @@ import com.kt.domain.paymenttype.PaymentType;
 import com.kt.domain.product.Product;
 import com.kt.domain.user.Gender;
 import com.kt.domain.user.User;
-import com.kt.dto.discount.request.DiscountCreateRequest;
-import com.kt.dto.payment.PaymentCreateRequest;
 import com.kt.repository.discount.DiscountRepository;
 import com.kt.repository.discountmembership.DiscountMembershipRepository;
 import com.kt.repository.membership.MembershipRepository;
@@ -109,13 +108,13 @@ class PaymentServiceTest {
 
 	@Test
 	void 주문에_대한_결제_생성_가능() {
-		paymentService.create(결제요청(), user.getId());
+		paymentService.create(토스_결제_응답(), user.getId());
 
 		Payment payment = paymentRepository.findAll().get(0);
 
-		assertThat(payment.getTotalPrice()).isEqualTo(20000);
+		assertThat(payment.getTotalPrice()).isEqualTo(23000);
 		assertThat(payment.getDeliveryFee()).isEqualTo(3000);
-		assertThat(payment.getFinalPrice()).isEqualTo(23000);
+		assertThat(payment.getFinalPrice()).isEqualTo(20000);
 
 		Order updatedOrder = orderRepository.findById(order.getId()).get();
 		assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.PAID);
@@ -137,15 +136,20 @@ class PaymentServiceTest {
 			new DiscountMembership(membershipDiscount, membership)
 		);
 
-		paymentService.create(결제요청(), user.getId());
+		paymentService.create(토스_결제_응답(), user.getId());
 
 		Payment payment = paymentRepository.findAll().get(0);
 
-		assertThat(payment.getTotalPrice()).isEqualTo(18000);
-		assertThat(payment.getFinalPrice()).isEqualTo(21000);
+		assertThat(payment.getTotalPrice()).isEqualTo(23000);
+		assertThat(payment.getFinalPrice()).isEqualTo(20000);
 	}
 
-	private PaymentCreateRequest 결제요청() {
-		return new PaymentCreateRequest(order.getId(), paymentType.getId());
+	private Map<String, Object> 토스_결제_응답() {
+		return Map.of(
+			"orderId", order.getId() + "-" + System.currentTimeMillis(),
+			"paymentKey", "test_payment_key_" + System.currentTimeMillis(),
+			"method", "CARD",
+			"totalAmount", 23000
+		);
 	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #162 


## 🔨변경 사항(Changes)
1. 결제 화면 구성(toss 테스트 API, 추가 기능으로 orderId와 jwt 토큰 입력칸으로 주문 정보 조회)
2. 결제 요청(/api/payments/confirm)
3. 결제 승인(api.tosspayments.com/v1/payments/confirm)
4. 결제 취소(/api/payments/{paymentId}/cancel)

test 환경변수
TOSS_PAYMENTS_API_URL=https://api.tosspayments.com/v1/payments;
TOSS_PAYMENTS_CLIENT_KEY=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm;
TOSS_PAYMENTS_SECRET_KEY=test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6

## 😉리뷰 요구사항
1. 결제 화면 호출 : http://localhost:8080/payment-test.html
2. 주문ID, 로그인 후 발급받은 토큰 입력 후 정보 가져오기(주문 상태에 따라서 결제 위젯 호출/결제 취소/안내문구노출 분기)
3. 가능한 결제 : 퀵계좌이체, 신용/체크카드, tosspay, 카카오페이, 네이버페이(휴대폰, 페이코는 불가)
   * 카카오 페이 결제 시 카카오페이에 연결된 계좌에서 실제로 충전만됌(모든 결제는 실제 결제X)
4. 결제 취소는 PAID, PROCESSING, SHIPPED, DELIVERED 상태에서만 가능(이외에 반품이나 환불 상태는 좀 애매하네요..)
5. 결제 취소 및 승인 테스트시 토스 결제 활용 시 실제 핸드폰 알림이 와서 편합니다