### PR TITLE
feat: 이메일 검증 개발

### DIFF
--- a/src/main/java/com/kt/common/exception/ErrorCode.java
+++ b/src/main/java/com/kt/common/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
 	DUPLICATED_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디입니다."),
 	DOES_NOT_MATCH_OLD_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호가 일치하지 않습니다."),
 	CAN_NOT_ALLOWED_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다."),
+    DUPLICATED_EMAIL(HttpStatus.BAD_REQUEST, "중복되는 이메일입니다."),
 
 	//product
 	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
@@ -111,6 +112,13 @@ public enum ErrorCode {
 	ALREADY_WISHLISTED(HttpStatus.BAD_REQUEST, "이미 찜한 상품입니다."),
 	WISHLIST_ADD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "찜 추가에 실패했습니다."),
 	NOT_FOUND_WISHLIST(HttpStatus.BAD_REQUEST, "찜하지 않은 상품입니다."),
+
+    //certify
+    EXPIRED_CERTIFICATION_CODE(HttpStatus.BAD_REQUEST,"만료된 코드입니다."),
+    FAILED_MORE_THAN_FIVE_TIMES(HttpStatus.BAD_REQUEST,"5회이상 시도하여 잠금상태입니다."),
+    CERTIFICATION_CODE_NOT_FOUND(HttpStatus.BAD_REQUEST,"인증코드를 찾을 수 없습니다."),
+    INVALID_CERTIFICATION_CODE(HttpStatus.BAD_REQUEST,"틀린 코드입니다."),
+    NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST,"인증되지않은 이메일입니다."),
 
 	//vector
 	NOT_FOUND_VECTOR_STORE(HttpStatus.BAD_REQUEST, "존재하지 않는 벡터 스토어입니다."),

--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfiguration {
 
 	private static final String[] GET_PERMIT_ALL = {"/api/health/**", "/swagger-ui.html","/swagger-ui/**", "/v3/api-docs/**", "/actuator/**", "/payment-*.html", "/api/payments/client-key", "/*.css", "/api/chats", "/api/chats/**"};
-	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login","/api/admin/users/auth/signup", "/api/admin/users/auth/login","/api/users/reissue", "/api/payments/confirm"};
+	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login","/api/admin/users/auth/signup", "/api/admin/users/auth/login","/api/users/reissue", "/api/payments/confirm","/api/certify/**"};
 	private static final String[] PUT_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] PATCH_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] DELETE_PERMIT_ALL = {"/api/v1/public/**"};

--- a/src/main/java/com/kt/controller/certify/CertifyController.java
+++ b/src/main/java/com/kt/controller/certify/CertifyController.java
@@ -1,0 +1,38 @@
+package com.kt.controller.certify;
+
+import com.kt.common.response.ApiResult;
+import com.kt.common.support.SwaggerAssistance;
+import com.kt.dto.certify.EmailCertificationRequest;
+import com.kt.dto.certify.EmailRequest;
+import com.kt.service.certify.CertifyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Certify", description = "이메일 검증 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/certify")
+public class CertifyController extends SwaggerAssistance{
+
+    private final CertifyService certifyService;
+
+    @PostMapping("/code")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "이메일 검증 코드 생성")
+    public ApiResult<Void> createCode(@RequestBody EmailRequest email){
+        certifyService.createCode(email.email());
+        return ApiResult.ok();
+    }
+
+    @PostMapping("/email")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "코드를 통한 이메일 검증")
+    public ApiResult<Void> certify(@Valid @RequestBody EmailCertificationRequest emailCertificationRequest){
+        certifyService.certifyEmail(emailCertificationRequest);
+        return ApiResult.ok();
+    }
+}

--- a/src/main/java/com/kt/domain/certify/Certify.java
+++ b/src/main/java/com/kt/domain/certify/Certify.java
@@ -70,7 +70,7 @@ public class Certify extends BaseEntity {
     }
 
     public boolean isVerified() {
-        if(this.expiresAt.equals(CertifyStatus.VERIFIED)){
+        if(this.codeStatus.equals(CertifyStatus.VERIFIED)){
             this.verifiedAt = LocalDateTime.now();
             return true;
         }

--- a/src/main/java/com/kt/domain/certify/Certify.java
+++ b/src/main/java/com/kt/domain/certify/Certify.java
@@ -1,0 +1,80 @@
+package com.kt.domain.certify;
+
+import com.kt.common.support.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Certify extends BaseEntity {
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String certifyCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CertifyStatus codeStatus;
+
+    @Column(nullable = false)
+    private int attempts;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime lockedAt;
+
+    private LocalDateTime verifiedAt;
+
+    public void changeStatus(CertifyStatus codeStatus){ // 코드 사용여부등 상태확인용도
+        this.codeStatus = codeStatus;
+    }
+
+    public void initAttempts(){ // 시도횟수 초기화
+        this.attempts = 0;
+    }
+
+    public void increaseAttemptsAndLock() {
+        this.attempts++;
+        if (this.attempts >= 5) {
+            this.codeStatus = CertifyStatus.LOCKED;
+            this.lockedAt = LocalDateTime.now();
+        }
+    }
+
+    public static Certify create(String email, String code, LocalDateTime expire) {
+        Certify certify = new Certify();
+        certify.email = email;
+        certify.certifyCode = code;
+        certify.codeStatus = CertifyStatus.PENDING;
+        certify.attempts = 0;
+        certify.expiresAt = expire;
+        return certify;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return this.expiresAt.isBefore(now);
+    }
+
+    public boolean isLocked() {
+        return this.codeStatus == CertifyStatus.LOCKED;
+    }
+
+    public boolean isSameCode(String code) {
+        return this.certifyCode.equals(code);
+    }
+
+    public boolean isVerified() {
+        if(this.expiresAt.equals(CertifyStatus.VERIFIED)){
+            this.verifiedAt = LocalDateTime.now();
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/kt/domain/certify/Certify.java
+++ b/src/main/java/com/kt/domain/certify/Certify.java
@@ -76,5 +76,18 @@ public class Certify extends BaseEntity {
         }
         return false;
     }
+    public void markVerifiedForTest(LocalDateTime expiresAt) {
+        this.codeStatus = CertifyStatus.VERIFIED;
+        this.expiresAt = expiresAt;
+    }
+    public static Certify TestVerify(String email, String code, LocalDateTime expiresAt) {
+        Certify c = new Certify();
+        c.email = email;
+        c.certifyCode = code;
+        c.codeStatus = CertifyStatus.PENDING;
+        c.expiresAt = expiresAt;
+        return c;
+    }
+
 
 }

--- a/src/main/java/com/kt/domain/certify/CertifyStatus.java
+++ b/src/main/java/com/kt/domain/certify/CertifyStatus.java
@@ -1,0 +1,8 @@
+package com.kt.domain.certify;
+
+public enum CertifyStatus {
+    PENDING,
+    LOCKED,
+    VERIFIED,
+    EXPIRED
+}

--- a/src/main/java/com/kt/dto/certify/EmailCertificationRequest.java
+++ b/src/main/java/com/kt/dto/certify/EmailCertificationRequest.java
@@ -1,0 +1,16 @@
+package com.kt.dto.certify;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailCertificationRequest(
+        @Schema(description = "이메일", example = "test@example.com")
+        @NotBlank
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
+        String email,
+        @NotNull
+        String code
+) {
+}

--- a/src/main/java/com/kt/dto/certify/EmailRequest.java
+++ b/src/main/java/com/kt/dto/certify/EmailRequest.java
@@ -1,0 +1,13 @@
+package com.kt.dto.certify;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EmailRequest(
+        @Schema(description = "이메일", example = "test@example.com")
+        @NotBlank
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$")
+        String email
+) {
+}

--- a/src/main/java/com/kt/repository/certify/CertifyRepository.java
+++ b/src/main/java/com/kt/repository/certify/CertifyRepository.java
@@ -1,0 +1,10 @@
+package com.kt.repository.certify;
+
+import com.kt.domain.certify.Certify;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface CertifyRepository extends JpaRepository<Certify, Long> {
+    Optional<Certify> findTopByEmailOrderByCreatedAtDesc(String email);
+
+}

--- a/src/main/java/com/kt/repository/user/UserRepository.java
+++ b/src/main/java/com/kt/repository/user/UserRepository.java
@@ -30,4 +30,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 		return findById(id).orElseThrow(() -> new CustomException(errorCode));
 	}
     Optional<User> findByLoginId(String loginId);
+    Boolean existsByEmailAndIsDeletedFalse(String email);
 }

--- a/src/main/java/com/kt/service/certify/CertifyService.java
+++ b/src/main/java/com/kt/service/certify/CertifyService.java
@@ -1,0 +1,78 @@
+package com.kt.service.certify;
+
+import com.kt.common.exception.CustomException;
+import com.kt.common.exception.ErrorCode;
+import com.kt.domain.certify.Certify;
+import com.kt.domain.certify.CertifyStatus;
+import com.kt.dto.certify.EmailCertificationRequest;
+import com.kt.notification.MailSendRequest;
+import com.kt.notification.MailSendService;
+import com.kt.repository.certify.CertifyRepository;
+import com.kt.repository.user.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@RequiredArgsConstructor
+@Service
+public class CertifyService {
+
+    private final UserRepository userRepository;
+    private final CertifyRepository certifyRepository;
+    private final MailSendService mailSendService;
+    @Transactional
+    public void certifyEmail(EmailCertificationRequest req) {
+        String email = req.email();
+        LocalDateTime now = LocalDateTime.now();
+
+        if (userRepository.existsByEmailAndIsDeletedFalse(email)) {
+            throw new CustomException(ErrorCode.DUPLICATED_EMAIL);
+        }
+
+        Certify certify = certifyRepository.findTopByEmailOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.CERTIFICATION_CODE_NOT_FOUND));
+
+        if (certify.isLocked()) { // 5회이상 틀릴시 잠금, 초과처럼 에러코드를 작성했지만 이상이 맞습니다...
+            throw new CustomException(ErrorCode.FAILED_MORE_THAN_FIVE_TIMES);
+        }
+
+        if (certify.isExpired(now)) { // 코드 유효기간 만료
+            certify.changeStatus(CertifyStatus.EXPIRED);
+            throw new CustomException(ErrorCode.EXPIRED_CERTIFICATION_CODE);
+        }
+
+        if (certify.isSameCode(req.code())) { // 이메일 인증통과
+            certify.changeStatus(CertifyStatus.VERIFIED);
+            certify.initAttempts();
+            return;
+        }
+
+        certify.increaseAttemptsAndLock(); // 실패시 틀림 처리
+        throw new CustomException(ErrorCode.INVALID_CERTIFICATION_CODE);
+    }
+
+
+    @Transactional
+    public void createCode(String email) { // 인증을 위한 난수 생성, secureRandom을 통해 강한 난수를 생성할수도있다 -> 좀 과한 것 같으니 제외
+        Random RANDOM = new Random();
+        StringBuilder builder = new StringBuilder(6);
+        for (int i = 0; i < 6; i++) {
+            builder.append(RANDOM.nextInt(10)); // 0 ~ 9
+        }
+        String code = builder.toString();
+        LocalDateTime expire = LocalDateTime.now().plusMinutes(5L);
+        Certify certifyCode = Certify.create(email,code,expire);
+        certifyRepository.save(certifyCode);
+
+        MailSendRequest request = new MailSendRequest(
+                email,
+                "이메일 인증 코드입니다.",
+                "코드: \n" + code
+        );
+        mailSendService.sendEmail(request);
+    }
+
+}

--- a/src/main/java/com/kt/service/certify/CertifyService.java
+++ b/src/main/java/com/kt/service/certify/CertifyService.java
@@ -75,4 +75,15 @@ public class CertifyService {
         mailSendService.sendEmail(request);
     }
 
+    public boolean validateEmailVerified(String email) {
+        Certify certify = certifyRepository.findTopByEmailOrderByCreatedAtDesc(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.CERTIFICATION_CODE_NOT_FOUND));
+
+        if (certify.isVerified()) {
+            return true;
+        }
+        return false;
+    }
+
+
 }

--- a/src/main/java/com/kt/service/user/UserService.java
+++ b/src/main/java/com/kt/service/user/UserService.java
@@ -18,6 +18,7 @@ import com.kt.repository.shoppingaddress.ShoppingAddressRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.security.CustomUserDetails;
 import com.kt.security.JwtTokenProvider;
+import com.kt.service.certify.CertifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,7 +43,7 @@ public class UserService {
     private static final String DEFAULT_MEMBERSHIP_LEVEL = "BRONZE";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String AUTH_HEADER = "Authorization";
-    private final Certify certify;
+    private final CertifyService certifyService;
 
     public boolean checkLoginIdDuplicated(String loginId) {
         return userRepository.existsByLoginIdAndIsDeletedFalse(loginId);
@@ -54,7 +55,7 @@ public class UserService {
         if (checkLoginIdDuplicated(request.loginId())) {
             throw new CustomException(ErrorCode.DUPLICATED_LOGIN_ID);
         }
-        if(!certify.isVerified()){
+        if(!certifyService.validateEmailVerified(request.email())){
             throw new CustomException(ErrorCode.NOT_VERIFIED_EMAIL);
         }
         Membership defaultMembership = membershipRepository.findByLevel(DEFAULT_MEMBERSHIP_LEVEL)

--- a/src/main/java/com/kt/service/user/UserService.java
+++ b/src/main/java/com/kt/service/user/UserService.java
@@ -3,6 +3,7 @@ package com.kt.service.user;
 import com.kt.common.exception.CustomException;
 import com.kt.common.exception.ErrorCode;
 import com.kt.domain.auth.RefreshToken;
+import com.kt.domain.certify.Certify;
 import com.kt.domain.membership.Membership;
 import com.kt.domain.shoppingaddress.ShoppingAddress;
 import com.kt.domain.user.Role;
@@ -17,21 +18,13 @@ import com.kt.repository.shoppingaddress.ShoppingAddressRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.security.CustomUserDetails;
 import com.kt.security.JwtTokenProvider;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
-
-import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
-import java.util.Date;
 
 import static com.kt.common.support.ObjectUtils.orElseIfEmpty;
 
@@ -49,6 +42,7 @@ public class UserService {
     private static final String DEFAULT_MEMBERSHIP_LEVEL = "BRONZE";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String AUTH_HEADER = "Authorization";
+    private final Certify certify;
 
     public boolean checkLoginIdDuplicated(String loginId) {
         return userRepository.existsByLoginIdAndIsDeletedFalse(loginId);
@@ -59,6 +53,9 @@ public class UserService {
 
         if (checkLoginIdDuplicated(request.loginId())) {
             throw new CustomException(ErrorCode.DUPLICATED_LOGIN_ID);
+        }
+        if(!certify.isVerified()){
+            throw new CustomException(ErrorCode.NOT_VERIFIED_EMAIL);
         }
         Membership defaultMembership = membershipRepository.findByLevel(DEFAULT_MEMBERSHIP_LEVEL)
                 .orElseThrow(() -> new IllegalStateException("기본 멤버십이 설정되어 있지 않습니다."));
@@ -233,11 +230,4 @@ public class UserService {
         user.changeRole(request.role());
     }
 
-    private String resolveBearer(String request) {
-        if (request == null || !request.startsWith("Bearer ")) {
-            throw new CustomException(ErrorCode.INVALID_JWT_TOKEN);
-        }
-
-        return request.substring(BEARER_PREFIX.length());
-    }
 }

--- a/src/test/java/com/kt/service/user/UserServiceTest.java
+++ b/src/test/java/com/kt/service/user/UserServiceTest.java
@@ -2,6 +2,8 @@ package com.kt.service.user;
 
 import com.kt.common.exception.CustomException;
 import com.kt.common.exception.ErrorCode;
+import com.kt.domain.certify.Certify;
+import com.kt.domain.certify.CertifyStatus;
 import com.kt.domain.membership.Membership;
 import com.kt.domain.user.Gender;
 import com.kt.domain.user.Role;
@@ -9,6 +11,7 @@ import com.kt.domain.user.User;
 import com.kt.dto.user.request.UserAdminUpdateRequest;
 import com.kt.dto.user.request.UserCreateRequest;
 import com.kt.dto.user.request.UserUpdateRequest;
+import com.kt.repository.certify.CertifyRepository;
 import com.kt.repository.membership.MembershipRepository;
 import com.kt.repository.user.UserRepository;
 import com.kt.security.CustomUserDetails;
@@ -19,11 +22,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +36,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class UserServiceTest {
+
+    private void givenVerifiedEmail(String email) {
+        Certify certify = Certify.TestVerify(email, "000000", LocalDateTime.now().plusMinutes(10));
+        certify.markVerifiedForTest(LocalDateTime.now().plusMinutes(10));
+        certifyRepository.save(certify);
+    }
 
     // 유저 유닛 테스트 작성
 
@@ -42,6 +52,8 @@ class UserServiceTest {
     private UserRepository userRepository;
     @Autowired
     private MembershipRepository membershipRepository;
+    @Autowired
+    private CertifyRepository certifyRepository;
 
     @BeforeEach
     void setUp(){
@@ -66,7 +78,9 @@ class UserServiceTest {
                 "BRONZE"
         );
 
+        givenVerifiedEmail(request.email());
         userService.create(request);
+
 
         User savedUser = userRepository.findByLoginIdAndIsDeletedFalse(request.loginId())
                 .orElseThrow(() -> new IllegalStateException("유저가 저장되지 않았습니다."));
@@ -122,6 +136,7 @@ class UserServiceTest {
                 "BRONZE"
         );
 
+        givenVerifiedEmail(request.email());
         userService.create(request);
 
         // 같은 loginId로 또 가입 시도하면 CustomException 발생
@@ -462,6 +477,7 @@ class UserServiceTest {
                 LocalDate.of(2000, 1, 1),
                 "BRONZE"
         );
+        givenVerifiedEmail(request1.email());
         userService.create(request1);
 
         User savedUser = userRepository.findByLoginIdAndIsDeletedFalse("rejoin_user")
@@ -491,6 +507,7 @@ class UserServiceTest {
         );
 
 
+        givenVerifiedEmail(request2.email());
         userService.create(request2);
 
 


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #131 

## 🔨변경 사항(Changes)
회원가입시 이메일을 검증하는 기능입니다
1. certify 컨트롤러에서 코드 생성 및 검증 진행
- pending,verified,locked,expired로 상태구분
- 5회이상 틀릴시 제한 발생(일정시간이후 풀리도록 조치할예정 - 미개발)
- 검증통과시 횟수 초기화
- 기간만료시 에러발생(발급시간으로 부터 5분)

2. 검증 통과시 회원가입 허용
3. 검증 미통과시 회원가입 제한(코드 상태기반)
4. (미개발)스케쥴러를 통해 사용이 끝난 코드 정리

## 😉리뷰 요구사항
미처 생각치 못한 허점이나 기능 로직상에 이상이 있다면 말씀해주시고 해당 기능을 개발을 했지만 테스트는 현재 시간상 그리고 혹시 모를 사고를 미연에 방지하기위해  로컬에서 진행했습니다. 최종발표때 해당 내용을 적용해서 시연영상을 찍을지,언급하고 넘어갈지 의견 주시면 감사하겠습니다.