### PR TITLE
fix: AI 챗봇 응답을 JSON 기반 답변 그대로 사용하도록 수정

### DIFF
--- a/src/main/java/com/kt/integration/openai/advisor/OpenAICustomAdvisor.java
+++ b/src/main/java/com/kt/integration/openai/advisor/OpenAICustomAdvisor.java
@@ -82,34 +82,30 @@ public class OpenAICustomAdvisor implements BaseAdvisor {
 		String answer = "";
 		if (topScoreSearchData.content() != null) {
 			answer = topScoreSearchData.content().stream()
-				.map(c -> extractAnswerFromVectorResult(c.text()))
+				.map(OpenAIResponse.Content::text)
 				.filter(s -> s != null && !s.isBlank())
-				.findFirst()
-				.orElse("");
+				.collect(java.util.stream.Collectors.joining("\n"));
 		}
-
 		String contextText;
 
 		// FAQ가 없으면 안내, 있으면 FAQ JSON 기반 답변
 		if (answer.isBlank()) {
 			contextText = "죄송하지만, 현재 FAQ에 등록된 정보 외에는 답변할 수 없습니다.";
+		} else {
+			contextText = """
+
+            [참고 정보]
+            %s
+            """.formatted(answer);
 		}
-
 		// FAQ가 있을 경우 기존 로직 그대로
-		contextText = """
-        다음은 참고 정보이다.
-        아래 내용을 기반으로 사용자의 질문에 답변하되,
-        최종 답변 문장만 출력하라.
-
-        [참고 정보]
-        %s
-        """.formatted(answer);
 
 		var newPrompt = prompt.augmentSystemMessage(contextText);
 
 		return chatClientRequest.mutate()
 			.prompt(newPrompt)
 			.build();
+
 	}
 
 	@Override

--- a/src/main/java/com/kt/integration/openai/api/DefaultChatApi.java
+++ b/src/main/java/com/kt/integration/openai/api/DefaultChatApi.java
@@ -22,14 +22,11 @@ public class DefaultChatApi implements OpenAIChatApi {
 	public String search(String query) {
 		return clientClient.prompt()
 			.system("""
-				너는 고객센터 챗봇이다.
-				제공된 참고 정보를 바탕으로 질문에 답변하되,
-				최종 답변 문장만 출력해라.
-				설명, 출처, 문맥, JSON 형식은 절대 포함하지 마라.
-				한두 문장으로 간결하게 답변해라.
-				""")
-			.user(query)
-			.call()
-			.content();
+            너의 작업은 "복사-붙여넣기"이다.
+
+            규칙:
+            [참고 정보]에 있는 answer 텍스트를 글자 단위로 그대로 출력한다.
+            요약/의역/정리/문장부호 변경/공백 변경을 절대 하지 않는다.
+            [참고 정보]가 없으면 정확히 다음만 출력한다: 죄송하지만, 현재 FAQ에 등록된 정보 외에는 답변할 수 없습니다.""").user(query).call().content();
 	}
 }


### PR DESCRIPTION
## 📝요약(Summary)
이슈 번호 : #번호


## 🔨변경 사항(Changes)
-DefaultChatApi 에서 시스템 프롬프트 수정 (챗봇이 JSON 답변을 가공하지 않고, 그대로 답변하도록 강제)
-OpenAICustomAdvisor 에서 챗봇이 스스로 답변을 재구성하지 못하게 하고, JSON 답변만 가져오게 하기 위해 contextText 를 %s 로만 설정

## 😉리뷰 요구사항

