### PR TITLE
feat: ratelimit 설정에서 ON/OFF 변경 가능하도록 추가

### DIFF
--- a/src/main/java/com/kt/ShoppingApplication.java
+++ b/src/main/java/com/kt/ShoppingApplication.java
@@ -3,11 +3,13 @@ package com.kt;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableJpaAuditing
+@EnableAspectJAutoProxy
 public class ShoppingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/kt/common/ratelimit/aspect/RateLimitAspect.java
+++ b/src/main/java/com/kt/common/ratelimit/aspect/RateLimitAspect.java
@@ -19,11 +19,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Aspect
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@ConditionalOnProperty(name = "ratelimit.enabled", havingValue = "true", matchIfMissing = true)
 public class RateLimitAspect {
 
 	private final RateLimitManager rateLimitManager;

--- a/src/main/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilter.java
+++ b/src/main/java/com/kt/common/ratelimit/filter/GlobalRateLimitFilter.java
@@ -19,9 +19,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(name = "ratelimit.enabled", havingValue = "true", matchIfMissing = true)
 public class GlobalRateLimitFilter extends OncePerRequestFilter {
 
 	private static final int MAX_REQUEST_SECONDS = 100;

--- a/src/main/java/com/kt/common/ratelimit/key/RateLimitKeyGenerator.java
+++ b/src/main/java/com/kt/common/ratelimit/key/RateLimitKeyGenerator.java
@@ -12,9 +12,11 @@ import com.kt.security.CustomUserDetails;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Component
 @Slf4j
+@ConditionalOnProperty(name = "ratelimit.enabled", havingValue = "true", matchIfMissing = true)
 public class RateLimitKeyGenerator {
 
 	public String generateKey(KeyType keyType, HttpServletRequest request, String httpMethod, String path) {

--- a/src/main/java/com/kt/common/ratelimit/manager/RateLimitManager.java
+++ b/src/main/java/com/kt/common/ratelimit/manager/RateLimitManager.java
@@ -12,10 +12,12 @@ import io.github.bucket4j.ConsumptionProbe;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@ConditionalOnProperty(name = "ratelimit.enabled", havingValue = "true", matchIfMissing = true)
 public class RateLimitManager {
 
 	private final ProxyManager<String> proxyManager;

--- a/src/main/java/com/kt/config/RateLimitConfiguration.java
+++ b/src/main/java/com/kt/config/RateLimitConfiguration.java
@@ -3,9 +3,9 @@ package com.kt.config;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 
@@ -13,7 +13,7 @@ import io.github.bucket4j.caffeine.CaffeineProxyManager;
 import io.github.bucket4j.distributed.proxy.ProxyManager;
 
 @Configuration
-@EnableAspectJAutoProxy
+@ConditionalOnProperty(name = "ratelimit.enabled", havingValue = "true", matchIfMissing = true)
 public class RateLimitConfiguration {
 
 	private static final int CACHE_MAX_SIZE = 100000;

--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -18,13 +18,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
-@RequiredArgsConstructor
 public class SecurityConfiguration {
 
 	private static final String[] GET_PERMIT_ALL = {"/api/health/**", "/swagger-ui.html","/swagger-ui/**", "/v3/api-docs/**", "/actuator/**", "/payment-*.html", "/api/payments/client-key", "/*.css", "/api/chats", "/api/chats/**"};
@@ -35,6 +34,16 @@ public class SecurityConfiguration {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final ObjectMapper objectMapper;
 	private final GlobalRateLimitFilter globalRateLimitFilter;
+
+	public SecurityConfiguration(
+		JwtTokenProvider jwtTokenProvider,
+		ObjectMapper objectMapper,
+		@Autowired(required = false) GlobalRateLimitFilter globalRateLimitFilter
+	) {
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.objectMapper = objectMapper;
+		this.globalRateLimitFilter = globalRateLimitFilter;
+	}
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
@@ -69,7 +78,9 @@ public class SecurityConfiguration {
                 .logout(logout -> logout.disable())
                 .csrf(AbstractHttpConfigurer::disable);
 
-		http.addFilterBefore(globalRateLimitFilter, UsernamePasswordAuthenticationFilter.class);
+		if (globalRateLimitFilter != null) {
+			http.addFilterBefore(globalRateLimitFilter, UsernamePasswordAuthenticationFilter.class);
+		}
 
 		http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,objectMapper), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,6 @@ slack:
 
 server:
   port: 8080
+
+ratelimit:
+  enabled: true


### PR DESCRIPTION

## 📝요약(Summary)
이슈 번호 : -

## 🔨변경 사항(Changes)
- 추가 및 변경 파일 : GlobalRateLimitFilter, RateLimitAspect, RateLimitManager, RateLimitKeyGenerator, RateLimitConfiguration
- @EnableAspectJAutoProxy를 ShoppingApplication으로 이동 (조건부 비활성화 시에도 AOP 유지)
- SecurityConfiguration에서 GlobalRateLimitFilter를 Optional 주입으로 변경
- application.yml에 ratelimit.enabled: true / false로 ratelimit 등록/해제 가능하도록 변경


## 😉리뷰 요구사항

