### PR TITLE
feat: 테스트용 결제 목업 API 추가

### DIFF
--- a/src/main/java/com/kt/config/SecurityConfiguration.java
+++ b/src/main/java/com/kt/config/SecurityConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfiguration {
 
 	private static final String[] GET_PERMIT_ALL = {"/api/health/**", "/swagger-ui.html","/swagger-ui/**", "/v3/api-docs/**", "/actuator/**", "/payment-*.html", "/api/payments/client-key", "/*.css", "/api/chats", "/api/chats/**"};
-	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login","/api/admin/users/auth/signup", "/api/admin/users/auth/login","/api/users/reissue", "/api/payments/confirm"};
+	private static final String[] POST_PERMIT_ALL = {"/api/users/auth/signup", "/api/users/auth/login","/api/admin/users/auth/signup", "/api/admin/users/auth/login","/api/users/reissue", "/api/payments/confirm", "/api/mock/**"};
 	private static final String[] PUT_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] PATCH_PERMIT_ALL = {"/api/v1/public/**"};
 	private static final String[] DELETE_PERMIT_ALL = {"/api/v1/public/**"};

--- a/src/main/java/com/kt/controller/payment/MockPaymentController.java
+++ b/src/main/java/com/kt/controller/payment/MockPaymentController.java
@@ -1,0 +1,47 @@
+package com.kt.controller.payment;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kt.common.response.ApiResult;
+import com.kt.service.payment.PaymentFacade;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/mock/payments")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "mock.payment.enabled", havingValue = "true")
+public class MockPaymentController {
+
+	private final PaymentFacade paymentFacade;
+
+	@PostMapping("/confirm")
+	public ApiResult<Long> mockConfirm(@RequestBody MockPaymentRequest request) {
+		Map<String, Object> fakeTossResponse = Map.of(
+			"paymentKey", "mock_" + UUID.randomUUID(),
+			"totalAmount", request.amount(),
+			"method", request.method()
+		);
+
+		Long paymentId = paymentFacade.completePayment(
+			fakeTossResponse, request.userId(), request.orderId()
+		);
+
+		return ApiResult.ok(paymentId);
+	}
+
+	public record MockPaymentRequest(
+		Long userId,
+		Long orderId,
+		Long amount,
+		String method
+	) {
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,5 +55,9 @@ toss:
     secret-key: ${payments.secret-key:test_gsk_docs_OaPz8L5KdmQXkzRz3y47BMw6}
     api-url: ${payments.api-url:https://api.tosspayments.com/v1/payments}
 
+mock:
+  payment:
+    enabled: true
+
 server:
   port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,3 +21,10 @@ slack:
 
 server:
   port: 8080
+
+ratelimit:
+  enabled: false
+
+mock:
+  payment:
+    enabled: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,6 +35,9 @@ spring:
 #      host: ${redis.host:localhost}
 #      port: ${redis.port:6379}
 
+ratelimit:
+  enabled: true
+
 jwt:
   secret: kt-cloud-tech-up-shopping-202511171107
   access-token-expiration: 300000


### PR DESCRIPTION
## 📝요약(Summary)
부하테스트용 결제 목업 API 추가

## 🔨변경 사항(Changes)
- Toss API 호출 없이 결제 이력 INSERT + 재고 차감 + 주문 상태 변경을 수행하는 Mock 결제 API 추가 
- (POST /api/mock/payments/confirm)
- SecurityConfiguration에 /api/mock/** permitAll 추가 (인증 없이 호출 가능)

POST /api/mock/payments/confirm
{
  "userId": 1,
  "orderId": 1,
  "amount": 50000,
  "method": "CARD"
}